### PR TITLE
:pencil2: Fix model output types typo

### DIFF
--- a/caikit_pt/blocks/text_generation/peft_prompt_tuning.py
+++ b/caikit_pt/blocks/text_generation/peft_prompt_tuning.py
@@ -335,7 +335,7 @@ class PeftPromptTuning(BlockBase):
                 "<FPT36947542E>",
                 tuning_config.output_model_types in base_model.PROMPT_OUTPUT_TYPES,
                 "{} not supported for base model type {}".format(
-                    tuning_config.output_model_type, base_model.model_type
+                    tuning_config.output_model_types, base_model.model_type
                 ),
             )
             output_model_types = tuning_config.output_model_types


### PR DESCRIPTION
### Changes
- Fix `model_output_types` value error check typo