### PR TITLE
Update pyproject.toml accelerators version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
     "caikit-tgis-backend>=0.1.6,<0.2.0",
 
     # TODO: loosen dependencies
-    "accelerate==0.18.0",
+    "accelerate>=0.18.0",
     "datasets>=2.4.0",
     "huggingface-hub",
     "numpy==1.22.4",


### PR DESCRIPTION
Needs 19.0 or greater to install alongside current versions of caikit