### PR TITLE
:arrow_up: Loosen dependency version ranges

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,21 +14,21 @@ classifiers=[
     "License :: OSI Approved :: Apache Software License"
 ]
 dependencies = [
-    "caikit==0.7.0",
+    "caikit[all]>=0.9.0,<0.10.0",
     "caikit-tgis-backend>=0.1.6,<0.2.0",
 
     # TODO: loosen dependencies
     "accelerate>=0.18.0",
     "datasets>=2.4.0",
     "huggingface-hub",
-    "numpy==1.22.4",
-    "pandas==2.0.2",
-    "scikit-learn==1.2.2",
-    "scipy==1.8.1",
-    "tokenizers==0.13.3",
-    "torch==1.13.1",
-    "tqdm==4.65.0",
-    "transformers==4.27.1",
+    "numpy>=1.22.4",
+    "pandas>=1.5.0",
+    "scikit-learn>=1.1",
+    "scipy>=1.8.1",
+    "tokenizers>=0.13.3",
+    "torch>=1.13.1",
+    "tqdm>=4.65.0",
+    "transformers>=4.27.1",
     "peft@git+https://github.com/mayank31398/peft.git@mpt-os-test"
 ]
 


### PR DESCRIPTION
Loosen dependency version so that this project can be more easily used with various other projects

caikit versions include streaming support in [0.8.0](https://github.com/caikit/caikit/releases/tag/v0.8.0) and optional dependencies in [0.9.0](https://github.com/caikit/caikit/releases/tag/v0.9.0) thus the `[all]` is required

For: #11 