### PR TITLE
:arrow_up: Bump caikit and caikit-tgis-backend

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,8 +14,8 @@ classifiers=[
     "License :: OSI Approved :: Apache Software License"
 ]
 dependencies = [
-    "caikit[all]>=0.9.4,<0.10.0",
-    "caikit-tgis-backend>=0.1.7,<0.2.0",
+    "caikit[all]>=0.10.1,<0.11.0",
+    "caikit-tgis-backend>=0.1.8,<0.2.0",
 
     # TODO: loosen dependencies
     "accelerate>=0.18.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ classifiers=[
     "License :: OSI Approved :: Apache Software License"
 ]
 dependencies = [
-    "caikit[all]>=0.10.1,<0.11.0",
+    "caikit[runtime-grpc]>=0.10.1,<0.11.0",
     "caikit-tgis-backend>=0.1.8,<0.2.0",
 
     # TODO: loosen dependencies


### PR DESCRIPTION
- Bump `caikit` for bidirectional streaming support - https://github.com/caikit/caikit/releases/tag/v0.10.0 and https://github.com/caikit/caikit/releases/tag/v0.10.1
- Bump `caikit-tgis-backend` with corresponding version range updates (no functional changes here) - https://github.com/caikit/caikit-tgis-backend/releases/tag/v0.1.8

Closes #68 