### PR TITLE
Fix example scripts

### DIFF
--- a/examples/compare_local_vs_tgis_models.py
+++ b/examples/compare_local_vs_tgis_models.py
@@ -2,19 +2,9 @@
 # is added to the syspath if not running inside of a container.
 # Standard
 import json
-import time
 
 # Third Party
-from datasets import load_dataset
 from utils import SUPPORTED_DATASETS, load_model
-import torch
-
-# First Party
-import caikit
-
-# Local
-from caikit_nlp import data_model
-import caikit_nlp
 
 NUM_SAMPLES_TO_RUN = 100
 

--- a/examples/evaluate_model.py
+++ b/examples/evaluate_model.py
@@ -12,12 +12,9 @@ from utils import (
     SUPPORTED_DATASETS,
     SUPPORTED_METRICS,
     configure_random_seed_and_logging,
-    get_wrapped_evaluate_metric,
-    is_float,
     kill_tgis_container_if_exists,
     load_model,
     print_colored,
-    string_to_float,
 )
 
 # Local

--- a/examples/load_and_run_distributed_peft.py
+++ b/examples/load_and_run_distributed_peft.py
@@ -15,13 +15,9 @@ import subprocess
 import sys
 
 # First Party
-from caikit.core.module_backend_config import _CONFIGURED_BACKENDS, configure
 from caikit_tgis_backend import TGISBackend
 import alog
 import caikit
-
-# Local
-import caikit_nlp
 
 alog.configure("debug4")
 
@@ -37,15 +33,9 @@ if not which("text-generation-launcher"):
     ), "Text generation script not found!"
 
 # Configure caikit to prioritize TGIS backend
-_CONFIGURED_BACKENDS.clear()
-# load_timeout: 320
-#           grpc_port: null
-#           http_port: 3001
-#           health_poll_delay: 1.0
 caikit.configure(
     config_dict={"module_backends": {"priority": [TGISBackend.backend_type]}}
 )  # should not be necessary but just in case
-configure()  # backend configure
 
 # Load with TGIS backend
 prefix_model_path = os.path.join(PREFIX_PATH, "sample_prompt")

--- a/examples/utils.py
+++ b/examples/utils.py
@@ -12,7 +12,6 @@ sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
 from collections import namedtuple
 from shutil import which
 from typing import Any, Callable, Tuple
-import math
 import random
 
 # Third Party
@@ -23,7 +22,6 @@ import torch
 import transformers
 
 # First Party
-from caikit.core.module_backend_config import _CONFIGURED_BACKENDS, configure
 from caikit_tgis_backend import TGISBackend
 import alog
 import caikit
@@ -80,11 +78,9 @@ def get_distributed_model(model_path):
         kill_tgis_container_if_exists()
 
     # TODO: Enforce validation that TGIS is mounting the same model type
-    _CONFIGURED_BACKENDS.clear()
     caikit.configure(
         config_dict={"module_backends": {"priority": [TGISBackend.backend_type]}}
     )  # should not be necessary but just in case
-    configure()  # backend configure
     dist_model = caikit.load(model_path)
     # Sanity check; if we have an environment variable override for the model TGIS is using,
     # make sure that its suffix (base model name) aligns with what we have in our config.


### PR DESCRIPTION
Just noticed that our example scripts were broken by Caikit changes to module backends; this PR fixes things (mostly) and removes some unused imports.