### PR TITLE
Add eval fine tuning

### DIFF
--- a/caikit_nlp/modules/text_generation/fine_tuning.py
+++ b/caikit_nlp/modules/text_generation/fine_tuning.py
@@ -162,8 +162,15 @@ class FineTuning(ModuleBase):
             dataloader_pin_memory=False,
             gradient_accumulation_steps=accumulate_steps,
             eval_accumulation_steps=accumulate_steps,
+            logging_strategy="epoch",
+            disable_tqdm=True,
+            # NOTE: Following not possible without save and eval strategy
+            # load_best_model_at_end=True,
             # eval_steps=1,
             **dtype_based_params,
+            ## TODO: Make below configurable
+            # fsdp="full_shard auto_wrap",
+            # local_rank=0,
         )
 
         data_collator = DataCollatorForSeq2Seq(

--- a/caikit_nlp/modules/text_generation/fine_tuning.py
+++ b/caikit_nlp/modules/text_generation/fine_tuning.py
@@ -23,6 +23,7 @@ from transformers import (
     Seq2SeqTrainingArguments,
     Trainer,
 )
+import torch
 
 # First Party
 from caikit.core.data_model import DataStream
@@ -119,6 +120,23 @@ class FineTuning(ModuleBase):
             shuffle=True,
         )
 
+        ### Dtype based processing
+        # NOTE: Following is not exhaustive list of all parameters
+        # for all dtypes
+        if torch_dtype == torch.float16:
+            dtype_based_params = {
+                "fp16": True,
+            }
+        elif torch_dtype == torch.bfloat16:
+            dtype_based_params = {
+                "bf16": True,
+            }
+        else:
+            # default to float32
+            dtype_based_params = {}
+
+        ## TODO: Add automatic sharding selection based on number of parameters
+        # in base model
         ## TODO: Fetch trainer from resource
 
         # TODO: Make this whole thing configurable by end-users,
@@ -137,7 +155,6 @@ class FineTuning(ModuleBase):
             weight_decay=0.01,
             save_total_limit=3,
             predict_with_generate=True,
-            fp16=True,
             push_to_hub=False,
             no_cuda=False,  # Default
             generation_max_length=max_target_length,
@@ -146,6 +163,7 @@ class FineTuning(ModuleBase):
             gradient_accumulation_steps=accumulate_steps,
             eval_accumulation_steps=accumulate_steps,
             # eval_steps=1,
+            **dtype_based_params,
         )
 
         data_collator = DataCollatorForSeq2Seq(

--- a/caikit_nlp/modules/text_generation/fine_tuning.py
+++ b/caikit_nlp/modules/text_generation/fine_tuning.py
@@ -220,9 +220,7 @@ class FineTuning(ModuleBase):
             # data and model. Since the model is with Trainer at this point
             # and thus the device placement be according to training strategy,
             # its better to let Trainer handle the evaluation / prediction
-            # NOTE: Below statement requires merge of HF PR
-            # https://github.com/huggingface/transformers/pull/24759
-            # and subsequent release of `transformers` and updating the lib version in `caikit-nlp`
+
             # TODO: Add support for passing extra arguments to prediction_step
             _, generated_tokens, _ = self.model.prediction_step(
                 self.model.model,

--- a/caikit_nlp/modules/text_generation/fine_tuning.py
+++ b/caikit_nlp/modules/text_generation/fine_tuning.py
@@ -222,7 +222,7 @@ class FineTuning(ModuleBase):
 
             generated_text = self.tokenizer.batch_decode(
                 generated_tokens.detach().cpu().numpy(), skip_special_tokens=True
-            )
+            )[0]
 
         else:
             error(

--- a/caikit_nlp/modules/text_generation/fine_tuning.py
+++ b/caikit_nlp/modules/text_generation/fine_tuning.py
@@ -165,7 +165,7 @@ class FineTuning(ModuleBase):
             log.warning(
                 "<NLP64076114W>",
                 f"Number of epochs configured is {num_epochs} which is less than minimum 1. \
-                    No training will be performed"
+                    No training will be performed",
             )
 
             return cls(

--- a/caikit_nlp/modules/text_generation/fine_tuning.py
+++ b/caikit_nlp/modules/text_generation/fine_tuning.py
@@ -161,6 +161,18 @@ class FineTuning(ModuleBase):
             # compute_metrics=compute_metrics,
         )
 
+        if num_epochs < 1:
+            log.warning(
+                "<NLP64076114W>",
+                f"Number of epochs configured is {num_epochs} which is less than minimum 1. \
+                    No training will be performed"
+            )
+
+            return cls(
+                tokenizer=base_model.tokenizer,
+                model=trainer,
+            )
+
         # Start training via Trainer.train function
         trainer.train()
         # NOTE: By default the model would be available in different ways
@@ -178,7 +190,7 @@ class FineTuning(ModuleBase):
 
     # pylint: disable=unused-argument
     def run(
-        self, text, preserve_input_text=False, max_new_tokens=20, min_new_tokens=0
+        self, text, preserve_input_text=False, max_new_tokens=128, min_new_tokens=0
     ) -> "GeneratedResult":
         """Run inference against the model running in TGIS.
 
@@ -190,7 +202,7 @@ class FineTuning(ModuleBase):
                 e.g., as a prefix.
             max_new_tokens: int
                 The maximum numbers of tokens to generate.
-                Default: 20
+                Default: 128
             min_new_tokens: int
                 The minimum numbers of tokens to generate.
                 Default: 0 - means no minimum

--- a/examples/run_fine_tuning.py
+++ b/examples/run_fine_tuning.py
@@ -159,6 +159,12 @@ def register_common_arguments(subparser: argparse.ArgumentParser) -> None:
         default="model_preds.json",
     )
     subparser.add_argument(
+        "--torch_dtype",
+        help="Torch dtype to use for training",
+        type=str,
+        default="float16",
+    )
+    subparser.add_argument(
         "--metrics",
         help="Metrics to calculate. Options: {}".format(list(SUPPORTED_METRICS.keys())),
         nargs="*",
@@ -213,6 +219,8 @@ def show_experiment_configuration(args, dataset_info, model_type) -> None:
         "- Maximum target sequence length: [{}]".format(args.max_target_length),
         "- Gradient accumulation steps: [{}]".format(args.accumulate_steps),
         "- Enable evaluation: [{}]".format(args.evaluate),
+        "- Evaluation metrics: [{}]".format(args.metrics),
+        "- Torch dtype to use for training: [{}]".format(args.torch_dtype),
     ]
     # Log and sleep for a few seconds in case people actually want to read this...
     print_colored("\n".join([print_str for print_str in print_strs if print_str]))
@@ -301,6 +309,7 @@ if __name__ == "__main__":
         max_source_length=args.max_source_length,
         max_target_length=args.max_target_length,
         lr=args.learning_rate,
+        torch_dtype="float16",
         batch_size=args.batch_size,
         accumulate_steps=args.accumulate_steps,
         num_epochs=args.num_epochs,

--- a/examples/run_fine_tuning.py
+++ b/examples/run_fine_tuning.py
@@ -6,13 +6,13 @@ Supported model types:
 
 # Standard
 from typing import Any, Tuple
-from tqdm import tqdm
 import argparse
 import json
 import os
 import shutil
 
 # Third Party
+from tqdm import tqdm
 from transformers import AutoConfig
 from utils import (
     ALOG_OPTS,
@@ -217,6 +217,7 @@ def show_experiment_configuration(args, dataset_info, model_type) -> None:
     # Log and sleep for a few seconds in case people actually want to read this...
     print_colored("\n".join([print_str for print_str in print_strs if print_str]))
 
+
 def get_model_preds_and_references(model, validation_stream):
     """Given a model & a validation stream, run the model against every example in the validation
     stream and compare the outputs to the target/output sequence.
@@ -248,7 +249,6 @@ def get_model_preds_and_references(model, validation_stream):
     )
 
 
-
 def export_model_preds(preds_file, predictions, validation_stream):
     """Exports a JSON file containing a list of objects, where every object contains:
         - source: str - Source string used for generation.
@@ -275,7 +275,6 @@ def export_model_preds(preds_file, predictions, validation_stream):
         )
     with open(preds_file, "w") as jfile:
         json.dump(pred_objs, jfile, indent=4, sort_keys=True)
-
 
 
 if __name__ == "__main__":
@@ -325,10 +324,7 @@ if __name__ == "__main__":
     print_colored("Getting model predictions...")
     predictions, references = get_model_preds_and_references(model, validation_stream)
 
-
-    export_model_preds(
-        args.preds_file, predictions, validation_stream
-    )
+    export_model_preds(args.preds_file, predictions, validation_stream)
 
     metric_funcs = [SUPPORTED_METRICS[metric_name] for metric_name in args.metrics]
     print_colored("Metrics to be calculated: {}".format(args.metrics))

--- a/examples/run_fine_tuning.py
+++ b/examples/run_fine_tuning.py
@@ -125,7 +125,7 @@ def register_common_arguments(subparser: argparse.ArgumentParser) -> None:
         "--learning_rate",
         help="Learning rate to use while training",
         type=float,
-        default=3e-2,
+        default=2e-5,
     ),
     subparser.add_argument(
         "--batch_size", help="Batch size to use while training", type=int, default=8
@@ -157,6 +157,12 @@ def register_common_arguments(subparser: argparse.ArgumentParser) -> None:
         "--preds_file",
         help="JSON file to dump raw source / target texts to.",
         default="model_preds.json",
+    )
+    subparser.add_argument(
+        "--metrics",
+        help="Metrics to calculate. Options: {}".format(list(SUPPORTED_METRICS.keys())),
+        nargs="*",
+        default=["accuracy"],
     )
 
 
@@ -306,7 +312,7 @@ if __name__ == "__main__":
     print_colored("[Training Complete]")
 
     # Prediction
-    sample_text = "this is sample text"
+    sample_text = "summarize: The Inflation Reduction Act lowers prescription drug costs, health care costs, and energy costs. It's the most aggressive action on tackling the climate crisis in American history, which will lift up American workers and create good-paying, union jobs across the country. It'll lower the deficit and ask the ultra-wealthy and corporations to pay their fair share. And no one making under $400,000 per year will pay a penny more in taxes."
     prediction_results = model.run(sample_text)
 
     print("Generated text: ", prediction_results)
@@ -324,7 +330,8 @@ if __name__ == "__main__":
         args.preds_file, predictions, validation_stream
     )
 
-    metric_funcs = list(SUPPORTED_METRICS.values())
+    metric_funcs = [SUPPORTED_METRICS[metric_name] for metric_name in args.metrics]
+    print_colored("Metrics to be calculated: {}".format(args.metrics))
 
     for metric_func in metric_funcs:
         metric_res = metric_func(predictions=predictions, references=references)

--- a/examples/utils.py
+++ b/examples/utils.py
@@ -35,7 +35,7 @@ from caikit_nlp.data_model import GenerationTrainRecord
 os.environ["TF_CPP_MIN_LOG_LEVEL"] = "2"
 
 ALOG_OPTS = {
-    "filters": "datasets:off,urllib3:off",
+    "filters": "datasets:off,urllib3:off,apscheduler:off,tzloc:off",
     "default_level": "error",
     "formatter": "pretty",
 }

--- a/examples/utils.py
+++ b/examples/utils.py
@@ -246,6 +246,7 @@ def load_billsum_dataset() -> Tuple[caikit.core.data_model.DataStream]:
     test_stream = build_stream("test")
     return (train_stream, validation_stream, test_stream)
 
+
 def load_samsum_dataset() -> Tuple[caikit.core.data_model.DataStream]:
     """Load the samsum dataset."""
 
@@ -264,6 +265,7 @@ def load_samsum_dataset() -> Tuple[caikit.core.data_model.DataStream]:
     validation_stream = build_stream("validation")
     test_stream = build_stream("test")
     return (train_stream, validation_stream, test_stream)
+
 
 def get_wrapped_evaluate_metric(metric_name: str, convert_to_numeric: bool) -> Callable:
     """Wrapper for running metrics out of evaluate which operate on numeric arrays

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
     "tokenizers>=0.13.3",
     "torch>=1.13.1",
     "tqdm>=4.65.0",
-    "transformers>=4.27.1",
+    "transformers>=4.31.0",
     "peft@git+https://github.com/mayank31398/peft.git@mpt-os-test"
 ]
 

--- a/tests/modules/text_generation/test_fine_tuning.py
+++ b/tests/modules/text_generation/test_fine_tuning.py
@@ -45,7 +45,9 @@ def test_train_model(disable_wip):
     pred = model.run("@bar what a cute cat!")
     assert isinstance(pred, GeneratedResult)
 
+
 ############################## Error Cases ################################
+
 
 def test_zero_epoch_case(disable_wip):
     """Test to ensure 0 epoch training request doesn't explode"""

--- a/tests/modules/text_generation/test_fine_tuning.py
+++ b/tests/modules/text_generation/test_fine_tuning.py
@@ -44,3 +44,24 @@ def test_train_model(disable_wip):
     # Ensure that we can get something out of it
     pred = model.run("@bar what a cute cat!")
     assert isinstance(pred, GeneratedResult)
+
+############################## Error Cases ################################
+
+def test_zero_epoch_case(disable_wip):
+    """Test to ensure 0 epoch training request doesn't explode"""
+    train_kwargs = {
+        "base_model": HFAutoSeq2SeqLM.bootstrap(
+            model_name=SEQ2SEQ_LM_MODEL, tokenizer_name=SEQ2SEQ_LM_MODEL
+        ),
+        "num_epochs": 0,
+        "train_stream": caikit.core.data_model.DataStream.from_iterable(
+            [
+                GenerationTrainRecord(
+                    input="@foo what a cute dog!", output="no complaint"
+                ),
+            ]
+        ),
+        "torch_dtype": torch.float32,
+    }
+    model = FineTuning.train(**train_kwargs)
+    assert isinstance(model.model, Trainer)

--- a/tests/modules/text_generation/test_fine_tuning.py
+++ b/tests/modules/text_generation/test_fine_tuning.py
@@ -13,13 +13,6 @@ from caikit_nlp.resources.pretrained_model import HFAutoSeq2SeqLM
 from tests.fixtures import SEQ2SEQ_LM_MODEL, disable_wip
 
 
-@pytest.mark.skip(
-    """
-We are skipping this test because we are waiting for new release
-of transformers library that includes bugfix that is currently breaking
-# run function
-"""
-)
 def test_train_model(disable_wip):
     """Ensure that we can train a model on some toy data for 1+ steps & run inference."""
     train_kwargs = {


### PR DESCRIPTION
Closes: #75 


### Changes
- Update transformers to latest version that enables bugfix for Trainer prediction
- Add [samsum](https://huggingface.co/datasets/samsum) and [billsum](https://huggingface.co/datasets/billsum) dataset from huggingface to test out summarization
- Change default input text length to support summarization
- Fix prediction generation batch decoding to single output mapping issue
- Add evaluation in fine-tuning notebook



### Test
1. Unit test: `tox -e py39 -- tests`
2. Evaluation example:
    ```python
   ALLOW_DOWNLOADS=true python3 run_fine_tuning.py --dataset "billsum"  --model_name t5-base --num_epochs 4 --output_dir tmp/with_loss_log --batch_size=8 --accumulate_steps 16 --max_source_length 1024 --metric rouge --torch_dtype float16
    ```

### Eval Results
