### PR TITLE
Api dumps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -165,3 +165,4 @@ modules.json
 prompt_prefixes
 sample_prompt
 transformers_cache
+generated_interfaces

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ classifiers=[
     "License :: OSI Approved :: Apache Software License"
 ]
 dependencies = [
-    "caikit[runtime-grpc]>=0.10.1,<0.12.0",
+    "caikit[runtime-grpc,runtime-http]>=0.11.3,<0.12.0",
     "caikit-tgis-backend>=0.1.8,<0.2.0",
 
     # TODO: loosen dependencies

--- a/scripts/dump_apis.sh
+++ b/scripts/dump_apis.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+# Make a directory with interfaces
+http_interface_dir="generated_interfaces/http"
+grpc_interface_dir="generated_interfaces/grpc"
+mkdir -p $http_interface_dir
+mkdir -p $grpc_interface_dir
+
+# Run the HTTP server in the background
+RUNTIME_LIBRARY=caikit_nlp python -m caikit.runtime.http_server &
+http_pid=$!
+
+# Sleep for a bit and then call it to get the swagger doc
+sleep 5
+curl http://localhost:8080/openapi.json | jq > $http_interface_dir/openapi.json
+
+# Kill the HTTP server and wait for it to die
+kill -9 $http_pid
+wait
+
+# Dump the gRPC interfaces
+RUNTIME_LIBRARY=caikit_nlp python -m caikit.runtime.dump_services $grpc_interface_dir


### PR DESCRIPTION
## Description

This PR adds a script to dump the HTTP and gRPC APIs. It also bumps the `caikit` bounds to support HTTP