### PR TITLE
:bug: Fix autoconfig always fetching info from model-hub

### DIFF
--- a/caikit_nlp/modules/text_generation/peft_prompt_tuning.py
+++ b/caikit_nlp/modules/text_generation/peft_prompt_tuning.py
@@ -312,7 +312,9 @@ class PeftPromptTuning(ModuleBase):
         #   type of the concrete class to bootstrap
         torch_dtype = get_torch_dtype(torch_dtype)
         if isinstance(base_model, str):
-            model_config = AutoConfig.from_pretrained(base_model)
+            model_config = AutoConfig.from_pretrained(
+                base_model, local_files_only=not get_config().allow_downloads
+            )
 
             resource_type = None
             for resource in cls.supported_resources:


### PR DESCRIPTION
### Changes
- Currently `Autoconfig` is by default going off of HF hub and fetching model configurations, which may not always be required depending on the usecase and may create confusion if the model version changed on HF Hub. This PR makes this configurable with the `ALLOW_DOWNLOADS` flag