### PR TITLE
Remote tgis text gen

### DIFF
--- a/caikit_nlp/modules/text_generation/text_generation.py
+++ b/caikit_nlp/modules/text_generation/text_generation.py
@@ -21,6 +21,7 @@ import os
 from transformers import AutoConfig
 
 # First Party
+from caikit import get_config
 from caikit.core.module_backends import BackendBase, backend_types
 from caikit.core.modules import ModuleBase, ModuleConfig, ModuleSaver, module
 from caikit.core.toolkit import error_handler
@@ -129,7 +130,10 @@ class TextGeneration(ModuleBase):
                 Object of TextGeneration class (model)
         """
         # pylint: disable=duplicate-code
-        model_config = AutoConfig.from_pretrained(base_model_path)
+        model_config = AutoConfig.from_pretrained(
+            base_model_path,
+            local_files_only=not get_config().allow_downloads,
+        )
         resource_type = None
         for resource in cls.supported_resources:
             if model_config.model_type in resource.SUPPORTED_MODEL_TYPES:

--- a/caikit_nlp/toolkit/tgis_utils.py
+++ b/caikit_nlp/toolkit/tgis_utils.py
@@ -53,7 +53,7 @@ def get_params(preserve_input_text, eos_token, max_new_tokens, min_new_tokens):
         token_ranks=True,
     )
     stopping = generation_pb2.StoppingCriteria(
-        stop_sequences=[eos_token],
+        stop_sequences=[eos_token] if eos_token is not None else None,
         max_new_tokens=max_new_tokens,
         min_new_tokens=min_new_tokens,
     )

--- a/runtime_config.yaml
+++ b/runtime_config.yaml
@@ -2,23 +2,33 @@
 jvm_options: []
 
 runtime:
+  library: caikit_nlp
+  lazy_load_local_models: true
   batching:
     standalone-model:
       size: 0 # Set to batch size for batching
 
-module_backends:
-  enabled: true
-  priority:
-    - TGIS
-  configs:
-    tgis:
-      local:
-        load_timeout: 120
-        grpc_port: null
-        http_port: null
-        health_poll_delay: 1.0
-      connection:
-        hostname: "localhost:8033"
-        ca_cert_file: null
-        client_cert_file: null
-        client_key_file: null
+model_management:
+  initializers:
+    default:
+      type: LOCAL
+      config:
+        backend_priority:
+          - type: TGIS
+            config:
+              local:
+                load_timeout: 120
+                grpc_port: null
+                http_port: null
+                health_poll_delay: 1.0
+              remote_models:
+                flan-t5-xl:
+                  hostname: localhost:8033
+                llama-70b:
+                  hostname: localhost:8034
+
+              connection:
+                hostname: "foo.{model_id}:1234"
+                ca_cert_file: null
+                client_cert_file: null
+                client_key_file: null

--- a/runtime_config.yaml
+++ b/runtime_config.yaml
@@ -24,8 +24,10 @@ model_management:
               remote_models:
                 flan-t5-xl:
                   hostname: localhost:8033
+                  prompt_dir: tgis_prompts
                 llama-70b:
                   hostname: localhost:8034
+                  prompt_dir: tgis_prompts
 
               connection:
                 hostname: "foo.{model_id}:1234"

--- a/scripts/run_local.sh
+++ b/scripts/run_local.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
-mkdir -p models
-
 cd $(dirname ${BASH_SOURCE[0]})/..
+mkdir -p models
 
 server=${SERVER:-"http"}
 

--- a/scripts/run_local.sh
+++ b/scripts/run_local.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+mkdir -p models
+
+cd $(dirname ${BASH_SOURCE[0]})/..
+
+server=${SERVER:-"http"}
+
+CONFIG_FILES=runtime_config.yaml \
+LOG_LEVEL=${LOG_LEVEL:-debug3} \
+LOG_FORMATTER=pretty \
+python -m caikit.runtime.${server}_server

--- a/tests/fixtures/__init__.py
+++ b/tests/fixtures/__init__.py
@@ -1,7 +1,7 @@
 """Helpful fixtures for configuring individual unit tests.
 """
 # Standard
-from typing import Iterable
+from typing import Iterable, Optional
 from unittest import mock
 import os
 import random
@@ -17,6 +17,7 @@ import transformers
 # First Party
 from caikit.interfaces.nlp.data_model import GeneratedTextResult
 from caikit_tgis_backend import TGISBackend
+from caikit_tgis_backend.tgis_connection import TGISConnection
 import caikit
 
 # Local
@@ -211,8 +212,22 @@ class StubTGISClient:
 
 
 class StubTGISBackend(TGISBackend):
+    def __init__(self, temp_dir: Optional[str] = None, *args, **kwargs):
+        self._temp_dir = temp_dir
+        super().__init__(*args, **kwargs)
+
     def get_client(self, base_model_name):
+        self._model_connections[base_model_name] = TGISConnection(
+            hostname="foo.bar",
+            prompt_dir=self._temp_dir,
+        )
         return StubTGISClient(base_model_name)
+
+
+@pytest.fixture
+def stub_tgis_backend():
+    with tempfile.TemporaryDirectory() as temp_dir:
+        yield StubTGISBackend(temp_dir)
 
 
 ### Args for commonly used datasets that we can use with our fixtures accepting params

--- a/tests/fixtures/__init__.py
+++ b/tests/fixtures/__init__.py
@@ -215,6 +215,7 @@ class StubTGISBackend(TGISBackend):
     def __init__(self, temp_dir: Optional[str] = None, *args, **kwargs):
         self._temp_dir = temp_dir
         super().__init__(*args, **kwargs)
+        self.load_prompt_artifacts = mock.MagicMock()
 
     def get_client(self, base_model_name):
         self._model_connections[base_model_name] = TGISConnection(

--- a/tests/fixtures/__init__.py
+++ b/tests/fixtures/__init__.py
@@ -212,9 +212,17 @@ class StubTGISClient:
 
 
 class StubTGISBackend(TGISBackend):
-    def __init__(self, temp_dir: Optional[str] = None, *args, **kwargs):
+    def __init__(
+        self,
+        config: Optional[dict] = None,
+        temp_dir: Optional[str] = None,
+        mock_remote: bool = False,
+    ):
         self._temp_dir = temp_dir
-        super().__init__(*args, **kwargs)
+        if mock_remote:
+            config = config or {}
+            config.update({"connection": {"hostname": "foo.{model_id}:123"}})
+        super().__init__(config)
         self.load_prompt_artifacts = mock.MagicMock()
 
     def get_client(self, base_model_name):
@@ -228,7 +236,7 @@ class StubTGISBackend(TGISBackend):
 @pytest.fixture
 def stub_tgis_backend():
     with tempfile.TemporaryDirectory() as temp_dir:
-        yield StubTGISBackend(temp_dir)
+        yield StubTGISBackend(temp_dir=temp_dir)
 
 
 ### Args for commonly used datasets that we can use with our fixtures accepting params

--- a/tests/modules/text_generation/test_peft_tgis_remote.py
+++ b/tests/modules/text_generation/test_peft_tgis_remote.py
@@ -13,16 +13,16 @@ import pytest
 # Local
 from caikit_nlp.modules.text_generation import PeftPromptTuningTGIS
 from tests.fixtures import (
-    StubTGISBackend,
     StubTGISClient,
     causal_lm_dummy_model,
     causal_lm_train_kwargs,
+    stub_tgis_backend,
 )
 
 SAMPLE_TEXT = "Hello stub"
 
 
-def test_load_and_run(causal_lm_dummy_model):
+def test_load_and_run(causal_lm_dummy_model, stub_tgis_backend):
     """Ensure we can export an in memory model, load it, and (mock) run it with the right text & prefix ID."""
     # Patch our stub backend into caikit so that we don't actually try to start TGIS
     causal_lm_dummy_model.verbalizer = "hello distributed {{input}}"
@@ -34,7 +34,7 @@ def test_load_and_run(causal_lm_dummy_model):
         # Also, save the name of the dir + prompt ID, which is the path TGIS expects for the prefix ID
         with tempfile.TemporaryDirectory() as model_dir:
             causal_lm_dummy_model.save(model_dir)
-            mock_tgis_model = PeftPromptTuningTGIS.load(model_dir, StubTGISBackend())
+            mock_tgis_model = PeftPromptTuningTGIS.load(model_dir, stub_tgis_backend)
             model_prompt_dir = os.path.split(model_dir)[-1]
 
         # Run an inference request, which is wrapped around our mocked Generate call
@@ -53,7 +53,7 @@ def test_load_and_run(causal_lm_dummy_model):
         assert model_prompt_dir == stub_generation_request.prefix_id
 
 
-def test_load_and_run_stream_out(causal_lm_dummy_model):
+def test_load_and_run_stream_out(causal_lm_dummy_model, stub_tgis_backend):
     """Ensure we can export an in memory model, load it, and (mock) run output streaming
     with the right text & prefix ID."""
     # Patch our stub backend into caikit so that we don't actually try to start TGIS
@@ -66,7 +66,7 @@ def test_load_and_run_stream_out(causal_lm_dummy_model):
         # Also, save the name of the dir + prompt ID, which is the path TGIS expects for the prefix ID
         with tempfile.TemporaryDirectory() as model_dir:
             causal_lm_dummy_model.save(model_dir)
-            mock_tgis_model = PeftPromptTuningTGIS.load(model_dir, StubTGISBackend())
+            mock_tgis_model = PeftPromptTuningTGIS.load(model_dir, stub_tgis_backend)
             model_prompt_dir = os.path.split(model_dir)[-1]
 
         # Run an inference request, which is wrapped around our mocked GenerateStream call

--- a/tests/modules/text_generation/test_peft_tgis_remote.py
+++ b/tests/modules/text_generation/test_peft_tgis_remote.py
@@ -68,6 +68,7 @@ def test_load_and_run_stream_out(causal_lm_dummy_model, stub_tgis_backend):
             causal_lm_dummy_model.save(model_dir)
             mock_tgis_model = PeftPromptTuningTGIS.load(model_dir, stub_tgis_backend)
             model_prompt_dir = os.path.split(model_dir)[-1]
+            assert stub_tgis_backend.load_prompt_artifacts.called_once()
 
         # Run an inference request, which is wrapped around our mocked GenerateStream call
         stream_result = mock_tgis_model.run_stream_out(

--- a/tox.ini
+++ b/tox.ini
@@ -43,3 +43,12 @@ setenv =
     FLIT_USERNAME = __token__
 commands = flit publish
 skip_install = True
+
+[testenv:build]
+description = build wheel
+deps = flit==3.8
+passenv =
+    FLIT_PASSWORD
+setenv =
+    FLIT_USERNAME = __token__
+commands = flit build


### PR DESCRIPTION
## Description

This PR makes updates to `peft_tgis_remote` and `text_generation`, the two `text_generation` module implementations that use a `TGISBackend`, to make them work with remote TGIS connections and no local artifacts. The changes include:

* Updating the `save/load` logic in `TextGeneration` to support saving and loading without artifacts
* Update the `save/load` logic in `TextGeneration` to preserve the base model name
* Update `PeftPromptTuningTGIS` to call the backend's `load_prompt_artifacts` to get the artifacts "loaded" to TGIS. In practice, this just means copying them to a preconfigured "prompt_dir" that the `TGISBackend` is assuming is a shared volume mount with TGIS for the prompt cache.

## Testing

Aside from unit tests, I've tested this out with a locally running server and port-forwards to TGIS. The testing setup looked like:


1. Get the server up and running with port forards

    ```sh
    # Port forward the two models, one for a prompt and one for a "base" model
    k port-forward svc/llama2-70b-inference-server 8034:8033 &
    k port-forward svc/flan-t5-3b-inference-server 8033:8033 &

    # Run the server locally
    ./scripts/run_local.sh
    ```

2.  Get the server to load some models by copying the attached stub models into `models`

    [sample_models.tgz](https://github.com/caikit/caikit-nlp/files/12188929/sample_models.tgz)

4. Call the "base" model and see some results!

    ```sh
    curl -X 'POST' \
      'http://localhost:8080/api/v1/llama-70b/task/text-generation' \
      -H 'accept: application/json' \
      -H 'Content-Type: application/json' \
      -d '{
      "inputs": "this is a test"
    }'
    ```

