### PR TITLE
Closes #134

### DIFF
--- a/examples/run_fine_tuning.py
+++ b/examples/run_fine_tuning.py
@@ -313,7 +313,11 @@ if __name__ == "__main__":
 
     # Init the resource & Build the tuning config from our dataset/arg info
     print_colored("[Loading the base model resource...]")
-    base_model = model_type.bootstrap(args.model_name, tokenizer_name=args.model_name, torch_dtype=args.torch_dtype)
+    base_model = model_type.bootstrap(
+        args.model_name, 
+        tokenizer_name=args.model_name, 
+        torch_dtype=args.torch_dtype
+    )
 
     # Then actually train the model & save it
     print_colored("[Starting the training...]")

--- a/examples/run_fine_tuning.py
+++ b/examples/run_fine_tuning.py
@@ -313,7 +313,7 @@ if __name__ == "__main__":
 
     # Init the resource & Build the tuning config from our dataset/arg info
     print_colored("[Loading the base model resource...]")
-    base_model = model_type.bootstrap(args.model_name, tokenizer_name=args.model_name)
+    base_model = model_type.bootstrap(args.model_name, tokenizer_name=args.model_name, torch_dtype=args.torch_dtype)
 
     # Then actually train the model & save it
     print_colored("[Starting the training...]")

--- a/examples/run_fine_tuning.py
+++ b/examples/run_fine_tuning.py
@@ -314,9 +314,7 @@ if __name__ == "__main__":
     # Init the resource & Build the tuning config from our dataset/arg info
     print_colored("[Loading the base model resource...]")
     base_model = model_type.bootstrap(
-        args.model_name, 
-        tokenizer_name=args.model_name, 
-        torch_dtype=args.torch_dtype
+        args.model_name, tokenizer_name=args.model_name, torch_dtype=args.torch_dtype
     )
 
     # Then actually train the model & save it


### PR DESCRIPTION
Simple bugfix to pass the Caikit NLP CLI `--dtype` argument to bootstrapping, allowing half precision models to be loaded `.from_pretrained()`