### PR TITLE
:bug: Fix attention mask and task_id for MPT

### DIFF
--- a/caikit_nlp/toolkit/text_generation/model_run_utils.py
+++ b/caikit_nlp/toolkit/text_generation/model_run_utils.py
@@ -19,6 +19,7 @@ from typing import List, Optional, Tuple, Union
 
 # Third Party
 from transformers import StoppingCriteria, TextStreamer
+from peft.peft_model import PeftModel
 import numpy as np
 import torch
 
@@ -209,6 +210,9 @@ def generate_text_func(
 
     if "attention_mask" in inputs:
         gen_optional_params["attention_mask"] = inputs["attention_mask"]
+
+    if isinstance(model, PeftModel):
+        gen_optional_params["task_ids"] = torch.zeros(inputs["input_ids"].shape[0], dtype=inputs["input_ids"].dtype).to(model.device)
 
     with torch.no_grad():
         generate_ids = model.generate(

--- a/caikit_nlp/toolkit/text_generation/model_run_utils.py
+++ b/caikit_nlp/toolkit/text_generation/model_run_utils.py
@@ -18,8 +18,8 @@
 from typing import List, Optional, Tuple, Union
 
 # Third Party
-from transformers import StoppingCriteria, TextStreamer
 from peft.peft_model import PeftModel
+from transformers import StoppingCriteria, TextStreamer
 import numpy as np
 import torch
 
@@ -212,7 +212,9 @@ def generate_text_func(
         gen_optional_params["attention_mask"] = inputs["attention_mask"]
 
     if isinstance(model, PeftModel):
-        gen_optional_params["task_ids"] = torch.zeros(inputs["input_ids"].shape[0], dtype=inputs["input_ids"].dtype).to(model.device)
+        gen_optional_params["task_ids"] = torch.zeros(
+            inputs["input_ids"].shape[0], dtype=inputs["input_ids"].dtype
+        ).to(model.device)
 
     with torch.no_grad():
         generate_ids = model.generate(

--- a/caikit_nlp/toolkit/text_generation/model_run_utils.py
+++ b/caikit_nlp/toolkit/text_generation/model_run_utils.py
@@ -207,6 +207,9 @@ def generate_text_func(
         stop_sequences,
     )
 
+    if "attention_mask" in inputs:
+        gen_optional_params["attention_mask"] = inputs["attention_mask"]
+
     with torch.no_grad():
         generate_ids = model.generate(
             input_ids=inputs["input_ids"],

--- a/caikit_nlp/toolkit/text_generation/model_run_utils.py
+++ b/caikit_nlp/toolkit/text_generation/model_run_utils.py
@@ -211,6 +211,9 @@ def generate_text_func(
     if "attention_mask" in inputs:
         gen_optional_params["attention_mask"] = inputs["attention_mask"]
 
+    # NOTE: Below is required as `task_id` is a required field for generation
+    # with MPT in PEFT. We are manually setting task id to 0 vector since
+    # we do not allow setting task specific id anyways.
     if isinstance(model, PeftModel):
         gen_optional_params["task_ids"] = torch.zeros(
             inputs["input_ids"].shape[0], dtype=inputs["input_ids"].dtype


### PR DESCRIPTION
### Changes
- For causal-lm models we need attention mask to be able to run generate function
- `task_ids` is now a compulsory field in PEFT. However, we won't be getting this from users. Since we do not allow task specific selection at run time, and use methods like average, we can just fill the task ids with 0 vector to fix this issue.