### PR TITLE
Refactor / Consolidate Batch Tokenization for Causal Language Modeling

### DIFF
--- a/caikit_nlp/resources/pretrained_model/hf_auto_causal_lm.py
+++ b/caikit_nlp/resources/pretrained_model/hf_auto_causal_lm.py
@@ -71,6 +71,16 @@ class HFAutoCausalLM(PretrainedModelBase):
             example: GenerationTrainRecord | Mapping
                 Training data model object to convert a form we can learn on, or a Mapping
                 that has keys input/output.
+            tokenizer: AutoTokenizer
+                Tokenizer object to be applied to input records.
+            max_source_length: int
+                Maximum length for input sequences.
+            max_target_length: int
+                Maximum length for output sequences.
+            verbalizer: Union[None, str]
+                Verbalizer to be rendered into each text.
+            task_ids: Union[None, int]
+                Task IDs to be used for multiprompt tuning.
 
         Returns:
             DataStream[transformers.tokenization_utils_base.BatchEncoding]

--- a/caikit_nlp/resources/pretrained_model/hf_auto_causal_lm.py
+++ b/caikit_nlp/resources/pretrained_model/hf_auto_causal_lm.py
@@ -15,9 +15,9 @@
 Huggingface auto causal LM resource type
 """
 # Standard
-from copy import copy
 from collections.abc import Mapping
-from typing import Union
+from copy import copy
+from typing import Callable, List, Tuple, Union
 
 # Third Party
 from transformers import (
@@ -30,11 +30,16 @@ from transformers.models.auto import modeling_auto
 # First Party
 from caikit.core.data_model import DataStream
 from caikit.core.modules import module
+from caikit.core.toolkit import error_handler
+import alog
 
 # Local
 from ...data_model import GenerationTrainRecord, PromptOutputModelType
 from ...toolkit.verbalizer_utils import render_verbalizer
 from .base import PretrainedModelBase
+
+log = alog.use_channel("HFRCLM")
+error = error_handler.get(log)
 
 
 @module(
@@ -61,7 +66,7 @@ class HFAutoCausalLM(PretrainedModelBase):
         max_target_length: int,
         verbalizer: Union[None, str] = None,
         task_ids: Union[None, int] = None,
-    ) -> DataStream["BatchEncoding"]:
+    ) -> DataStream[BatchEncoding]:
         """Tokenization function to be used for causallm training; this function consumes a
         GenerationTrainRecord object and applies the verbalizer to it followed by
         the model tokenizer. Due to the nature of our training data with src/target seqs,
@@ -99,39 +104,51 @@ class HFAutoCausalLM(PretrainedModelBase):
         source = (
             source if verbalizer is None else render_verbalizer(verbalizer, example)
         )
-        
+
         source_ids = tokenizer(source, max_length=max_source_length, truncation=True)
         target_ids = tokenizer(target, max_length=max_target_length, truncation=True)
+
         # Force everything to a list of batch encodings; for non-batch mode, this just
         # puts it into a list. For batch mode, we get a list of batch encodings,
         # allowing us to standardize subsequent processing a bit.
-
         source_ids, num_target_samples = cls._force_to_batch_encoding_list(
-            source_ids,
-            target_ids,
-            batched_mode,
-            task_ids
+            source_ids, target_ids, batched_mode, task_ids
         )
 
-        def build_generator_func(source_ids, num_target_samples):
+        def build_generator_func(
+            source_ids: BatchEncoding, num_target_samples: int
+        ) -> Callable:
+            """Builds a generator that can be applied to a single batch encoding and its
+            corresponding original number of target samples.
+
+            source_ids: BatchEncoding
+                Source ID to generate different samples from.
+            num_target_samples: int
+                Number of target IDs; used for attention mask creation.
+            """
+
             def single_generator_func():
                 for idx in range(num_target_samples):
                     ret_source_ids = copy(source_ids)
                     ret_source_ids["attention_mask"] = cls._get_attention_mask(
-                        source_ids, 
+                        source_ids,
                         idx,
                         num_target_samples,
                     )
                     yield ret_source_ids
+
             return single_generator_func
 
         if not batched_mode:
             return DataStream(build_generator_func(source_ids, num_target_samples))
-        streams = [DataStream(build_generator_func(s_ids, n_target_samples)) for s_ids, n_target_samples in zip(source_ids, num_target_samples)]
+        streams = [
+            DataStream(build_generator_func(s_ids, n_target_samples))
+            for s_ids, n_target_samples in zip(source_ids, num_target_samples)
+        ]
         encoding_keys = source_ids[0].keys()
         return cls._collapse_streams_into_encoding(streams, encoding_keys)
 
-    def _get_data_collator(self, **kwargs):
+    def _get_data_collator(self, **kwargs) -> "transformers.DataCollator":
         """Function to return appropriate data collator based on resource.
 
         DataCollatorForLanguageModeling is used here which will dynamically
@@ -160,22 +177,54 @@ class HFAutoCausalLM(PretrainedModelBase):
             tokenizer=self._tokenizer, return_tensors="pt", **collator_kwargs
         )
 
-    def _force_to_batch_encoding_list(source_ids, target_ids, batch_mode, task_ids):
+    @staticmethod
+    def _force_to_batch_encoding_list(
+        source_ids: BatchEncoding,
+        target_ids: BatchEncoding,
+        batch_mode: bool,
+        task_ids: Union[None, int],
+    ) -> Tuple[Union[BatchEncoding, List[BatchEncoding]], Union[int, List[int]]]:
+        """Forces our inputs into either a single batch encoding (if we aren't running in batch
+        mode), or a list of Batch Encodings. I.e., a list of dicts instead of a dict of lists.
+        The primary reason that we do this is to allow us to easily map a common generator
+        func, regardless of whether or not we're running in batched mode.
+
+        Args:
+            source_ids: BatchEncoding
+                Source ID batch encoding; target ID info will be merged into this one.
+            target_ids: BatchEncoding
+                Target ID batch encoding; information will be merged into source ID encoding.
+            batch_mode: bool
+                Whether or not we are processing a batch.
+            task_ids: Union[None, int]
+                Optional task IDs for MPT to be propagated to produced encodings.
+
+        Returns:
+            Tuple[Union[BatchEncoding, List[BatchEncoding]], Union[int, List]]
+        """
         if not batch_mode:
             source_ids["input_ids"] = source_ids.input_ids + target_ids.input_ids
-            source_ids["task_ids"] = task_ids            
+            source_ids["task_ids"] = task_ids
             num_target_samples = len(target_ids.input_ids)
             return source_ids, num_target_samples
-        # Otherwise we need to expand the dict along its keys, 
+        # Otherwise we need to expand the dict along its keys,
         # mapping all of its encapsulated objects to new items.
         encodings = []
         num_target_samples = []
         id_keys = source_ids.keys()
+        key = None
+        error.value_check(
+            "<NLP94411004E>",
+            source_ids.keys(),
+            "Source ID batch encoding must have keys",
+        )
         for batch_idx in range(len(source_ids.input_ids)):
             new_encoding = BatchEncoding()
             for key in id_keys:
                 if key == "input_ids":
-                    new_encoding[key] = source_ids[key][batch_idx] + target_ids[key][batch_idx]
+                    new_encoding[key] = (
+                        source_ids[key][batch_idx] + target_ids[key][batch_idx]
+                    )
                 else:
                     new_encoding[key] = source_ids[key][batch_idx]
             num_target_samples.append(len(target_ids[key][batch_idx]))
@@ -183,15 +232,47 @@ class HFAutoCausalLM(PretrainedModelBase):
             encodings.append(new_encoding)
         return encodings, num_target_samples
 
-    def _get_attention_mask(source_ids, idx, num_target_samples):
+    @staticmethod
+    def _get_attention_mask(
+        source_ids: BatchEncoding, idx: int, num_target_samples: int
+    ) -> List[int]:
+        """Get the attention mask for a given target token from some source encoding.
+
+        Args:
+            source_ids: BatchEncoding
+                Source encoding that requires an attention mask.
+            idx: int
+                Index of the output token we attend up to.
+            num_target_samples: int
+                Length of the original target seequence being considered.
+
+        Returns:
+            List[int]
+                Binary attention mask.
+        """
         return (
             source_ids["attention_mask"]
             + [1] * (idx + 1)
             + [0] * (num_target_samples - idx - 1)
         )
 
-    @classmethod
-    def _collapse_streams_into_encoding(cls, streams, encoding_keys):
+    @staticmethod
+    def _collapse_streams_into_encoding(
+        streams: List[DataStream[BatchEncoding]], encoding_keys: "dict_keys"
+    ) -> BatchEncoding:
+        """Given a list of streams of batch encodings, collapse them back into
+        one encoding, i.e., the return value of the batch encoding.
+
+        Args:
+            streams: List[DataStream[BatchEncoding]]
+                Objects to be collapsed into a single encoding.
+            encoding_keys: dict_keys
+                Dictionary keys to copy over from batch encoding list.
+
+        Returns:
+            BatchEncoding
+                Collapsed batch encoding to be returned from tokenizatino func.
+        """
         new_encoding = BatchEncoding()
         for k in encoding_keys:
             new_encoding[k] = []

--- a/caikit_nlp/resources/pretrained_model/hf_auto_causal_lm.py
+++ b/caikit_nlp/resources/pretrained_model/hf_auto_causal_lm.py
@@ -100,8 +100,6 @@ class HFAutoCausalLM(PretrainedModelBase):
             source if verbalizer is None else render_verbalizer(verbalizer, example)
         )
 
-        # HACK: We shouldn't have to pad here, but the causal LM data collator dynamic padding
-        # does not appear to be playing nicely with the Huggingface trainer / torch fsdp...
         source_ids = tokenizer(source, max_length=max_source_length, truncation=True)
         target_ids = tokenizer(target, max_length=max_target_length, truncation=True)
         if batched_mode:


### PR DESCRIPTION
This PR is a rewrite of the batch tokenization logic for causal language modeling, with the primary goal of consolidating the batch / non-batched logic, removing the duplicate code, and prioritizing readability. Doing so will make implementing chunking etc much cleaner and less error prone.

The reason this code was (originally) super ugly is that BatchEncoding objects hold batches as a dict of lists and non-batched items directly. This makes them extremely annoying to write common code for, particularly when something complicated is happening and multiple samples are being yielded per entry in the batch.

This PR adds a pre/post processing step to convert the batch encoding to a list of batch encodings, consolidates the generator func, and adds a post processing step for batching to rebuild the batch encoding dict of lists. I also tried to combine redundant steps where possible to make up for the potential performance drop from pre/post processing.

### Mini Benchmark
The result is much more readable, and benchmarks show that the approximate performance of the refactored code to be close to the original. Here is a quick and dirty benchmark script - it pulls the Billsum dataset and times how long it takes on average to cycles through it with different source / target lengths.

```python
import time
from examples import utils
from caikit_nlp.resources.pretrained_model import HFAutoCausalLM
from datasets import IterableDataset as TransformersIterableDataset

# Time how long it takes to do the full causal LM tokenization + iteration with:
# source size=100, target_size=1
# source size=400, target_size=1
# source size=400, target_size=400
TIMING_CONFIGURATIONS = [
   {"max_source_length": 1, "max_target_length": 1},
   {"max_source_length": 100, "max_target_length": 1},
   {"max_source_length": 400, "max_target_length": 1},
   {"max_source_length": 400, "max_target_length": 400},
   {"max_source_length": 4000, "max_target_length": 4000},
]
NUM_CYCLES = 5

train_stream = utils.load_billsum_dataset()[0]
causal_lm = HFAutoCausalLM.bootstrap(
    model_name="bigscience/bloom-560m",
    tokenizer_name="bigscience/bloom-560m",
)

def get(train_stream):
    for data in train_stream:
        yield {"input": data.input, "output": data.output}

for configuration in TIMING_CONFIGURATIONS:
    fn_kwargs = {"tokenizer": causal_lm.tokenizer, **configuration}
    dataset = TransformersIterableDataset.from_generator(
        get, gen_kwargs={"train_stream": train_stream}
    )
    start = time.perf_counter()
    for _ in range(NUM_CYCLES):
        iter_dataset = dataset.map(
            causal_lm.tokenize_function,
            fn_kwargs=fn_kwargs,
            batched=True,
            remove_columns=["input", "output"],
        )
        for x in iter_dataset:
            pass
    stop = time.perf_counter()
    print("Elapsed sec/cycle for {} cycles using configuration: {}: {:.7f} seconds".format(NUM_CYCLES, configuration, (stop-start)/NUM_CYCLES))
```

Results running on a main:
```
Elapsed sec/cycle for 5 cycles using configuration: {'max_source_length': 1, 'max_target_length': 1}: 1.9887406 seconds
Elapsed sec/cycle for 5 cycles using configuration: {'max_source_length': 100, 'max_target_length': 1}: 1.1651814 seconds
Elapsed sec/cycle for 5 cycles using configuration: {'max_source_length': 400, 'max_target_length': 1}: 1.1439555 seconds
Elapsed sec/cycle for 5 cycles using configuration: {'max_source_length': 400, 'max_target_length': 400}: 8.4149436 seconds
Elapsed sec/cycle for 5 cycles using configuration: {'max_source_length': 4000, 'max_target_length': 4000}: 28.4439991 seconds
```

Results  running on this branch:
```
On my branch
Elapsed sec/cycle for 5 cycles using configuration: {'max_source_length': 1, 'max_target_length': 1}: 2.0212925 seconds
Elapsed sec/cycle for 5 cycles using configuration: {'max_source_length': 100, 'max_target_length': 1}: 1.1320408 seconds
Elapsed sec/cycle for 5 cycles using configuration: {'max_source_length': 400, 'max_target_length': 1}: 1.1338763 seconds
Elapsed sec/cycle for 5 cycles using configuration: {'max_source_length': 400, 'max_target_length': 400}: 8.4160768 seconds
Elapsed sec/cycle for 5 cycles using configuration: {'max_source_length': 4000, 'max_target_length': 4000}: 26.7061765 seconds
```
