### PR TITLE
Causal LM tokenization: Chunking and seq2seq Forward

### DIFF
--- a/caikit_nlp/modules/text_generation/peft_prompt_tuning.py
+++ b/caikit_nlp/modules/text_generation/peft_prompt_tuning.py
@@ -938,13 +938,13 @@ class PeftPromptTuning(ModuleBase):
         """
         (
             tokenize_function,
-            requires_unwrapping,
+            _,
         ) = base_model.build_task_tokenize_closure(
             tokenizer, max_source_length, max_target_length, verbalizer, task_ids=0
         )
         mapped_stream = train_stream.map(tokenize_function)
-        if requires_unwrapping:
-            mapped_stream = mapped_stream.flatten()
+        # if requires_unwrapping:
+        #     mapped_stream = mapped_stream.flatten()
         wrapped_stream = SimpleIterableStreamWrapper(mapped_stream, shuffle=shuffle)
         dataloader = DataLoader(
             wrapped_stream, collate_fn=collate_fn, batch_size=batch_size

--- a/caikit_nlp/modules/text_generation/peft_prompt_tuning.py
+++ b/caikit_nlp/modules/text_generation/peft_prompt_tuning.py
@@ -890,12 +890,13 @@ class PeftPromptTuning(ModuleBase):
             Callable
                 collate_fn to be used for processing batches from our datasets.
         """
-        if task_type == "CAUSAL_LM":
-            return DataCollatorForLanguageModeling(
-                tokenizer=tokenizer,
-                return_tensors="pt",
-                mlm=False,
-            )
+        # HACK: Do NOT use the causal LM collator (for now) because we want to set the labels ourselves...
+        # if task_type == "CAUSAL_LM":
+        #     return DataCollatorForLanguageModeling(
+        #         tokenizer=tokenizer,
+        #         return_tensors="pt",
+        #         mlm=False,
+        #     )
         return default_data_collator
 
     @staticmethod

--- a/caikit_nlp/modules/text_generation/peft_prompt_tuning.py
+++ b/caikit_nlp/modules/text_generation/peft_prompt_tuning.py
@@ -33,10 +33,7 @@ from peft import (
 from torch.optim import AdamW
 from torch.utils.data import DataLoader
 from tqdm import tqdm
-from transformers import (
-    AutoModelForCausalLM,
-    default_data_collator,
-)
+from transformers import AutoModelForCausalLM, default_data_collator
 from transformers.models.auto.tokenization_auto import AutoTokenizer
 from transformers.optimization import get_linear_schedule_with_warmup
 import numpy as np
@@ -931,10 +928,7 @@ class PeftPromptTuning(ModuleBase):
             torch.utils.data.DataLoader
                 DataLoader to be used for training / evaluating the stream data.
         """
-        (
-            tokenize_function,
-            _,
-        ) = base_model.build_task_tokenize_closure(
+        (tokenize_function, _,) = base_model.build_task_tokenize_closure(
             tokenizer, max_source_length, max_target_length, verbalizer, task_ids=0
         )
         mapped_stream = train_stream.map(tokenize_function)

--- a/caikit_nlp/modules/text_generation/text_generation_local.py
+++ b/caikit_nlp/modules/text_generation/text_generation_local.py
@@ -593,7 +593,7 @@ class TextGeneration(ModuleBase):
         mapped_dataset = dataset.map(
             base_model.tokenize_function,
             fn_kwargs=fn_kwargs,
-            batched=base_model.REQUIRES_TOKEN_UNWRAPPING,
+            batched=False,
             # Drop the input / output columns; we need to do this for dimensions to play
             # happily when operating on batched inputs for causal language modeling.
             remove_columns=["input", "output"],

--- a/caikit_nlp/resources/pretrained_model/hf_auto_causal_lm.py
+++ b/caikit_nlp/resources/pretrained_model/hf_auto_causal_lm.py
@@ -66,7 +66,7 @@ class HFAutoCausalLM(PretrainedModelBase):
         max_target_length: int,
         verbalizer: Union[None, str] = None,
         task_ids: Union[None, int] = None,
-        use_seq2seq_tokenization: bool = False,
+        use_seq2seq_tokenization: bool = True,
         chunk_size: int = 128,
         drop_remainder: bool = False,
     ) -> DataStream[BatchEncoding]:

--- a/caikit_nlp/resources/pretrained_model/hf_auto_causal_lm.py
+++ b/caikit_nlp/resources/pretrained_model/hf_auto_causal_lm.py
@@ -230,6 +230,14 @@ class HFAutoCausalLM(PretrainedModelBase):
         # Force everything to a list of batch encodings; for non-batch mode, this just
         # puts it into a list. For batch mode, we get a list of batch encodings,
         # allowing us to standardize subsequent processing a bit.
+        #
+        # For example, given chunk size 2, we might have something like:
+        # [
+        #   {'input_ids': [31, 48], 'attention_mask': [1, 1]},
+        #   {'input_ids': [47, 1], 'attention_mask': [1, 1]},
+        #   ...
+        # ]
+        # (where the above objects are batch encodings, which are a subclass of dict)
         source_id_chunks = cls._force_to_batch_encoding_list_of_chunks(
             source_ids, target_ids, batched_mode, task_ids, chunk_size, drop_remainder
         )
@@ -330,7 +338,7 @@ class HFAutoCausalLM(PretrainedModelBase):
                 encoding. Corresponds to target.
         """
         for k in left.keys():
-            left[k] = left[k] + right[k]
+            left[k].extend(right[k])
 
     @staticmethod
     def _split_encoding_into_chunks(

--- a/caikit_nlp/resources/pretrained_model/hf_auto_causal_lm.py
+++ b/caikit_nlp/resources/pretrained_model/hf_auto_causal_lm.py
@@ -382,34 +382,19 @@ class HFAutoCausalLM(PretrainedModelBase):
         sample_input_ids = model_inputs[
             "input_ids"
         ]  # NOTE - combined source + target + <FINAL_TOK_ID>
-        # TODO: can we handle the padding through the collator?
+
+        label_input_ids = labels["input_ids"]
+        model_inputs = tokenizer.pad(
+            model_inputs,
+            padding="max_length",
+            max_length=max_source_length
+        )
+
         if tokenizer.padding_side.lower() == "left":
-            # Do left padding
-            # labels["input_ids"] = [IGNORE_ID] * len(
-            #     sample_input_ids
-            # ) + label_input_ids
-            label_input_ids = labels["input_ids"]
-            model_inputs["input_ids"] = [tokenizer.pad_token_id] * (
-                max_source_length - len(sample_input_ids)
-            ) + sample_input_ids
-            model_inputs["attention_mask"] = [0] * (
-                max_source_length - len(sample_input_ids)
-            ) + model_inputs["attention_mask"]
             labels["input_ids"] = [IGNORE_ID] * (
                 max_source_length - len(sample_input_ids)
             ) + label_input_ids
         else:
-            # Do right padding
-            # labels["input_ids"] = [IGNORE_ID] * len(
-            #     sample_input_ids
-            # ) + label_input_ids
-            label_input_ids = labels["input_ids"]
-            model_inputs["input_ids"] = sample_input_ids + [
-                tokenizer.pad_token_id
-            ] * (max_source_length - len(sample_input_ids))
-            model_inputs["attention_mask"] = model_inputs["attention_mask"] + [
-                0
-            ] * (max_source_length - len(sample_input_ids))
             labels["input_ids"] = label_input_ids + [IGNORE_ID] * (
                 max_source_length - len(sample_input_ids)
             )

--- a/caikit_nlp/resources/pretrained_model/hf_auto_causal_lm.py
+++ b/caikit_nlp/resources/pretrained_model/hf_auto_causal_lm.py
@@ -37,6 +37,7 @@ import alog
 from ...data_model import GenerationTrainRecord, PromptOutputModelType
 from ...toolkit.verbalizer_utils import render_verbalizer
 from .base import PretrainedModelBase
+from .hf_auto_seq2seq_lm import HFAutoSeq2SeqLM
 
 log = alog.use_channel("HFRCLM")
 error = error_handler.get(log)
@@ -66,6 +67,7 @@ class HFAutoCausalLM(PretrainedModelBase):
         max_target_length: int,
         verbalizer: Union[None, str] = None,
         task_ids: Union[None, int] = None,
+        use_seq2seq_tokenization: bool = False,
     ) -> DataStream[BatchEncoding]:
         """Tokenization function to be used for causallm training; this function consumes a
         GenerationTrainRecord object and applies the verbalizer to it followed by
@@ -95,6 +97,16 @@ class HFAutoCausalLM(PretrainedModelBase):
         source, target = cls.decompose_example_io(example)
         # Determine if our mapped inputs are in batched mode or not
         batched_mode = isinstance(source, list) and isinstance(target, list)
+        if use_seq2seq_tokenization:
+            assert batched_mode is False
+            return HFAutoSeq2SeqLM.tokenize_function(
+                example=example,
+                tokenizer=tokenizer,
+                max_source_length=max_source_length,
+                max_target_length=max_target_length,
+                verbalizer=verbalizer,
+                task_ids=task_ids,
+            )
 
         # TODO: Handle batched verbalizer stuff!
         if batched_mode and verbalizer is not None:

--- a/caikit_nlp/resources/pretrained_model/hf_auto_seq2seq_lm.py
+++ b/caikit_nlp/resources/pretrained_model/hf_auto_seq2seq_lm.py
@@ -177,7 +177,17 @@ class HFAutoSeq2SeqLM(PretrainedModelBase):
         source = (
             source if verbalizer is None else render_verbalizer(verbalizer, example)
         )
+        return cls._tokenize_source_and_target(
+            tokenizer,
+            source,
+            target,
+            max_source_length,
+            max_target_length,
+            task_ids
+        )
 
+    @classmethod
+    def _tokenize_source_and_target(cls, tokenizer, source, target, max_source_length, max_target_length, task_ids):
         model_inputs = tokenizer(
             source,
             max_length=max_source_length,
@@ -199,5 +209,4 @@ class HFAutoSeq2SeqLM(PretrainedModelBase):
         model_inputs["labels"] = labels
         if task_ids is not None:
             model_inputs["task_ids"] = task_ids
-
         return model_inputs

--- a/caikit_nlp/resources/pretrained_model/hf_auto_seq2seq_lm.py
+++ b/caikit_nlp/resources/pretrained_model/hf_auto_seq2seq_lm.py
@@ -177,17 +177,7 @@ class HFAutoSeq2SeqLM(PretrainedModelBase):
         source = (
             source if verbalizer is None else render_verbalizer(verbalizer, example)
         )
-        return cls._tokenize_source_and_target(
-            tokenizer,
-            source,
-            target,
-            max_source_length,
-            max_target_length,
-            task_ids
-        )
 
-    @classmethod
-    def _tokenize_source_and_target(cls, tokenizer, source, target, max_source_length, max_target_length, task_ids):
         model_inputs = tokenizer(
             source,
             max_length=max_source_length,
@@ -209,4 +199,5 @@ class HFAutoSeq2SeqLM(PretrainedModelBase):
         model_inputs["labels"] = labels
         if task_ids is not None:
             model_inputs["task_ids"] = task_ids
+
         return model_inputs

--- a/tests/resources/test_pretrained_model.py
+++ b/tests/resources/test_pretrained_model.py
@@ -10,9 +10,9 @@ from unittest.mock import patch
 
 # Third Party
 from datasets import IterableDataset as TransformersIterableDataset
+from torch.utils.data import DataLoader
 import pytest
 import torch
-from torch.utils.data import DataLoader
 import transformers
 
 # First Party
@@ -229,6 +229,7 @@ def test_causal_lm_batch_tokenization(models_cache_dir):
         for k in indiv_res:
             assert indiv_res[k] == batched_res[k]
 
+
 ### 2. Tests for causal LM framed as a seq2seq problem
 # NOTE: For these tests, we should be careful to always test left and right padding
 @pytest.mark.parametrize(
@@ -245,7 +246,9 @@ def test_causal_lm_as_a_sequence_problem_no_truncation(models_cache_dir, padding
     max_lengths = 20
     # First, build the output we expect for left / right respectively...
     input_tok = causal_lm.tokenizer.encode(sample.input)
-    output_tok = causal_lm.tokenizer.encode(sample.output) + [causal_lm.tokenizer.eos_token_id]
+    output_tok = causal_lm.tokenizer.encode(sample.output) + [
+        causal_lm.tokenizer.eos_token_id
+    ]
     concat_res = input_tok + output_tok
     masked_res = ([-100] * len(input_tok)) + output_tok
 
@@ -254,11 +257,15 @@ def test_causal_lm_as_a_sequence_problem_no_truncation(models_cache_dir, padding
     assert len(output_tok) < (max_lengths + 1)
     pads_needed = (1 + 2 * max_lengths) - len(concat_res)
     if causal_lm.tokenizer.padding_side.lower() == "left":
-        expected_input_ids = torch.tensor([causal_lm.tokenizer.pad_token_id] * pads_needed + concat_res)
+        expected_input_ids = torch.tensor(
+            [causal_lm.tokenizer.pad_token_id] * pads_needed + concat_res
+        )
         expected_attn_mask = torch.tensor([0] * pads_needed + [1] * len(concat_res))
         expected_labels = torch.tensor([-100] * pads_needed + masked_res)
     else:
-        expected_input_ids = torch.tensor(concat_res + [causal_lm.tokenizer.pad_token_id] * pads_needed)
+        expected_input_ids = torch.tensor(
+            concat_res + [causal_lm.tokenizer.pad_token_id] * pads_needed
+        )
         expected_attn_mask = torch.tensor([1] * len(concat_res) + [0] * pads_needed)
         expected_labels = torch.tensor(masked_res + [-100] * pads_needed)
 
@@ -326,6 +333,7 @@ def test_seq2seq_tok_output_correctness(models_cache_dir):
     # Ensure we support MPT
     assert hasattr(tok_sample, "task_ids")
     assert tok_sample["task_ids"] == 0
+
 
 ### Tests for collator compatability
 # These tests should validate that we can use our tokenization function to

--- a/tests/resources/test_pretrained_model.py
+++ b/tests/resources/test_pretrained_model.py
@@ -113,7 +113,7 @@ def test_causal_lm_tokenize_func_contains_wrapped_stream(models_cache_dir):
         max_source_length=100,
         max_target_length=100,
         verbalizer="{{input}}",
-        use_seq2seq_tokenization=False,
+        use_seq2seq_approach=False,
     )
     map_stream = SAMPLE_TRAINING_DATA.map(tok_func)
     # Since tok_func for causal lm creates a datastream, we should get a stream
@@ -150,7 +150,7 @@ def test_causal_lm_tok_output_correctness(models_cache_dir, chunk_size, drop_rem
         max_target_length=100,
         verbalizer="{{input}}",
         task_ids=0,
-        use_seq2seq_tokenization=False,
+        use_seq2seq_approach=False,
         chunk_size=chunk_size,
         drop_remainder=drop_remainder,
     )
@@ -200,7 +200,7 @@ def test_causal_lm_batch_tokenization(models_cache_dir):
         "tokenizer": causal_lm.tokenizer,
         "max_source_length": 10,
         "max_target_length": 10,
-        "use_seq2seq_tokenization": False,
+        "use_seq2seq_approach": False,
     }
     # Create an iterable dataset by batching...
     def get(train_stream):
@@ -299,7 +299,7 @@ def test_causal_lm_seq2seq_tok_forward_no_batching(models_cache_dir):
         max_source_length=100,
         max_target_length=100,
         verbalizer="{{input}}",
-        use_seq2seq_tokenization=True,
+        use_seq2seq_approach=True,
     )[0]
     tok_func_seq2seq = HFAutoSeq2SeqLM.build_task_tokenize_closure(
         tokenizer=causal_lm.tokenizer,
@@ -332,10 +332,10 @@ def test_causal_lm_seq2seq_tok_forward_with_batching(models_cache_dir):
         "tokenizer": causal_lm.tokenizer,
         "max_source_length": 10,
         "max_target_length": 10,
-        "use_seq2seq_tokenization": True,
+        "use_seq2seq_approach": True,
     }
     seq2seq_kwargs = {
-        k: v for k, v in causal_lm_fn_kwargs.items() if k != "use_seq2seq_tokenization"
+        k: v for k, v in causal_lm_fn_kwargs.items() if k != "use_seq2seq_approach"
     }
 
     # Create an iterable dataset by batching...

--- a/tests/resources/test_pretrained_model.py
+++ b/tests/resources/test_pretrained_model.py
@@ -166,7 +166,8 @@ def test_causal_lm_tok_output_correctness(models_cache_dir, chunk_size, drop_rem
     has_remainder = False
     if len(concat_tok) > chunk_size:
         num_expected_chunks = len(concat_tok) // chunk_size
-        if num_expected_chunks * chunk_size != len(concat_tok):
+        # Should only care about the remainder if we are not dropping it
+        if num_expected_chunks * chunk_size != len(concat_tok) and not drop_remainder:
             has_remainder = True
     else:
         num_expected_chunks = 1

--- a/tests/resources/test_pretrained_model.py
+++ b/tests/resources/test_pretrained_model.py
@@ -131,7 +131,10 @@ def test_causal_lm_tokenize_func_contains_wrapped_stream(models_cache_dir):
 # 1 - simplest and minimal case
 # 3 - because the concat sequence is length 17, so we have a remainder
 # 100 - which is much larger than the concatenated seq and should yield one chunk
-@pytest.mark.parametrize("chunk_size,drop_remainder", [(1, True), (1, False), (3, True), (3, False), (100, True), (100, False)])
+@pytest.mark.parametrize(
+    "chunk_size,drop_remainder",
+    [(1, True), (1, False), (3, True), (3, False), (100, True), (100, False)],
+)
 def test_causal_lm_tok_output_correctness(models_cache_dir, chunk_size, drop_remainder):
     """Validate the tokenized results for the chunked language modeling objective."""
     causal_lm = HFAutoCausalLM.bootstrap(
@@ -170,15 +173,14 @@ def test_causal_lm_tok_output_correctness(models_cache_dir, chunk_size, drop_rem
     for idx in range(num_expected_chunks):
         assert len(tok_list[idx]["attention_mask"]) == chunk_size
         assert len(tok_list[idx]["input_ids"]) == chunk_size
-        assert all(atn==1 for atn in tok_list[idx]["attention_mask"])
+        assert all(atn == 1 for atn in tok_list[idx]["attention_mask"])
         assert tok_list[idx]["task_ids"] == 0
     # Check the remainder; lists should be the same length, but less than the chunk size
     if has_remainder:
         remainder = tok_list[-1]
         assert len(remainder["attention_mask"]) == len(remainder["input_ids"])
         assert len(remainder["input_ids"]) < chunk_size
-        assert all(atn==1 for atn in remainder["attention_mask"])
-
+        assert all(atn == 1 for atn in remainder["attention_mask"])
 
 
 def test_causal_lm_batch_tokenization(models_cache_dir):
@@ -245,6 +247,7 @@ def test_seq2seq_tokenize_func_contains_unwrapped_stream(models_cache_dir):
         map_stream.peek(), transformers.tokenization_utils_base.BatchEncoding
     )
 
+
 def test_seq2seq_tok_output_correctness(models_cache_dir):
     """Validate the correctness of the attention mask for the seq2seq task."""
     seq2seq = HFAutoSeq2SeqLM.bootstrap(
@@ -270,6 +273,7 @@ def test_seq2seq_tok_output_correctness(models_cache_dir):
     # Ensure we support MPT
     assert hasattr(tok_sample, "task_ids")
     assert tok_sample["task_ids"] == 0
+
 
 ### Tests for Causal LM -> seq2seq forwarded tokenization
 # Note - in all tests below, we always use the causal LM tokenizer, even when calling the
@@ -327,7 +331,9 @@ def test_causal_lm_seq2seq_tok_forward_with_batching(models_cache_dir):
         "max_target_length": 10,
         "use_seq2seq_tokenization": True,
     }
-    seq2seq_kwargs = {k: v for k,v in causal_lm_fn_kwargs.items() if k != "use_seq2seq_tokenization"}
+    seq2seq_kwargs = {
+        k: v for k, v in causal_lm_fn_kwargs.items() if k != "use_seq2seq_tokenization"
+    }
 
     # Create an iterable dataset by batching...
     def get(train_stream):
@@ -358,5 +364,6 @@ def test_causal_lm_seq2seq_tok_forward_with_batching(models_cache_dir):
         # And all of their values should be the same
         for k in clm_res:
             assert clm_res[k] == seq2seq_res[k]
+
 
 ### Tests for Causal LM tokenization chunking

--- a/tests/resources/test_pretrained_model.py
+++ b/tests/resources/test_pretrained_model.py
@@ -113,6 +113,7 @@ def test_causal_lm_tokenize_func_contains_wrapped_stream(models_cache_dir):
         max_source_length=100,
         max_target_length=100,
         verbalizer="{{input}}",
+        use_seq2seq_tokenization=False,
     )
     map_stream = SAMPLE_TRAINING_DATA.map(tok_func)
     # Since tok_func for causal lm creates a datastream, we should get a stream
@@ -149,6 +150,7 @@ def test_causal_lm_tok_output_correctness(models_cache_dir, chunk_size, drop_rem
         max_target_length=100,
         verbalizer="{{input}}",
         task_ids=0,
+        use_seq2seq_tokenization=False,
         chunk_size=chunk_size,
         drop_remainder=drop_remainder,
     )
@@ -198,6 +200,7 @@ def test_causal_lm_batch_tokenization(models_cache_dir):
         "tokenizer": causal_lm.tokenizer,
         "max_source_length": 10,
         "max_target_length": 10,
+        "use_seq2seq_tokenization": False,
     }
     # Create an iterable dataset by batching...
     def get(train_stream):


### PR DESCRIPTION
This PR is the nth rewrite of causal language modeling tokenization, _now_ changing it to:
- Let us use sequence type tokenization with causal language models if we want to
- Or enable chunking on the concatenated sequence, optionally dropping the remainder if the chunks are uneven

Sequence type tokenization is a port of the old causal LM tokenization logic with a bug fix for the concatenation sequence length; I have verified the quality matches approximately what we would expect from prompt tuning on RTE.

Chunking seems to be functional and has tests verifying output correctness but is not publicly exposed yet and therefore has not fully quality tested.

We need to be careful about collator compatibility when changing the chunking strategy, since prompt tuning and the base model resources/text generation currently manage collators for different model types differently. The main thing to be wary of is that the causal language modeling collator should _not_ be used with the sequence approach to avoid clobbering the labels.

Note that currently things are still being statically padded and using the default collator; it would be more ideal to:
- use the padding collator for dynamic padding when possible
- add better collator based tests operating on transformers datasets; this PR does start these tests a bit, but only covers the default collator, which does not necessarily need a torch dataset to work