### PR TITLE
Add ft loss logging

### DIFF
--- a/caikit_nlp/modules/text_generation/peft_prompt_tuning.py
+++ b/caikit_nlp/modules/text_generation/peft_prompt_tuning.py
@@ -1042,7 +1042,7 @@ class PeftPromptTuning(ModuleBase):
 
         training_loss_tracker = []
 
-        step_count = 0
+        step_count = 1
 
         for epoch in range(num_epochs):
             step_loss_log = {}

--- a/caikit_nlp/modules/text_generation/peft_prompt_tuning.py
+++ b/caikit_nlp/modules/text_generation/peft_prompt_tuning.py
@@ -1080,7 +1080,7 @@ class PeftPromptTuning(ModuleBase):
                     {
                         "epoch": epoch,
                         "step": step,
-                        "value": loss_val,
+                        "value": float(loss_val),
                         "timestamp": datetime.isoformat(datetime.now()),
                     }
                 )
@@ -1141,7 +1141,6 @@ class PeftPromptTuning(ModuleBase):
                         eval_epoch_loss,
                     )
 
-        error.value_check("<NLP66129758E>", len(training_loss_tracker) == num_epochs)
         return {"loss": training_loss_tracker}
 
     @classmethod

--- a/caikit_nlp/modules/text_generation/text_generation_local.py
+++ b/caikit_nlp/modules/text_generation/text_generation_local.py
@@ -371,15 +371,14 @@ class TextGeneration(ModuleBase):
                 # negatively impact the performance
                 "full_determinism": False,
                 # Required for iterable dataset
-                "max_steps": 5,
-                # "max_steps": cls.infer_max_steps(
-                #     num_epochs, batch_size, training_dataset
-                # ),
+                "max_steps": cls.infer_max_steps(
+                    num_epochs, batch_size, training_dataset
+                ),
                 # Some interesting parameters:
                 "auto_find_batch_size": True,
                 # NOTE: following can override above arguments in order
                 **filtered_training_arguments,
-                # **processing_configuration,
+                **processing_configuration,
                 **dtype_based_params,
             }
 
@@ -438,7 +437,7 @@ class TextGeneration(ModuleBase):
             sep_token=model.tokenizer.sep_token or None,
             eos_token=model.tokenizer.eos_token or None,
             pad_token=model.tokenizer.pad_token or None,
-            training_metadata=training_loss_history
+            training_metadata={"loss": training_loss_history}
         )
 
     @classmethod

--- a/caikit_nlp/modules/text_generation/text_generation_local.py
+++ b/caikit_nlp/modules/text_generation/text_generation_local.py
@@ -14,7 +14,6 @@
 
 
 # Standard
-from datetime import datetime
 from typing import Any, Dict, Optional, Union
 import gc
 import json
@@ -24,7 +23,7 @@ import tempfile
 # Third Party
 from datasets import Dataset
 from datasets import IterableDataset as TransformersIterableDataset
-from transformers import AutoConfig, AutoTokenizer, TrainerCallback
+from transformers import AutoConfig, AutoTokenizer
 import torch
 
 # First Party
@@ -366,7 +365,7 @@ class TextGeneration(ModuleBase):
                 "gradient_accumulation_steps": accumulate_steps,
                 "gradient_checkpointing": True,
                 "logging_strategy": "steps",
-                "logging_steps": 1, #logging at every step
+                "logging_steps": 1,  # logging at every step
                 # NOTE: This is explicitly set to false since it will
                 # negatively impact the performance
                 "full_determinism": False,
@@ -398,7 +397,6 @@ class TextGeneration(ModuleBase):
                 get_config().master_addr,
                 get_config().master_port,
             )
-
 
             if torch.cuda.is_available():
                 # NOTE: torch distributed can hang if run on CPUs,
@@ -437,7 +435,7 @@ class TextGeneration(ModuleBase):
             sep_token=model.tokenizer.sep_token or None,
             eos_token=model.tokenizer.eos_token or None,
             pad_token=model.tokenizer.pad_token or None,
-            training_metadata={"loss": training_loss_history}
+            training_metadata={"loss": training_loss_history},
         )
 
     @classmethod
@@ -611,14 +609,9 @@ class TextGeneration(ModuleBase):
     ) -> None:
         """Utility function to wrap trainer and execute training"""
 
-        # logging_callback = LoggingCallback()
-
         trainer = base_model.get_trainer(
             train_dataset=training_dataset, **training_args
         )
-
-        # Add logging callback
-        # trainer.add_callback(logging_callback)
 
         # Start training via Trainer.train function
         trainer.train()

--- a/caikit_nlp/modules/text_generation/text_generation_local.py
+++ b/caikit_nlp/modules/text_generation/text_generation_local.py
@@ -359,13 +359,16 @@ class TextGeneration(ModuleBase):
                 "dataloader_pin_memory": False,
                 "gradient_accumulation_steps": accumulate_steps,
                 "gradient_checkpointing": True,
+                "logging_strategy": "steps",
+                "logging_steps": 1, #logging at every step
                 # NOTE: This is explicitly set to false since it will
                 # negatively impact the performance
                 "full_determinism": False,
                 # Required for iterable dataset
-                "max_steps": cls.infer_max_steps(
-                    num_epochs, batch_size, training_dataset
-                ),
+                # "max_steps": cls.infer_max_steps(
+                #     num_epochs, batch_size, training_dataset
+                # ),
+                "max_steps": 5,
                 # Some interesting parameters:
                 "auto_find_batch_size": True,
                 # NOTE: following can override above arguments in order
@@ -585,6 +588,7 @@ class TextGeneration(ModuleBase):
         # Start training via Trainer.train function
         trainer.train()
 
+        breakpoint()
         # save the model temporarily and reload it
         # this is done, since otherwise the model might be distributed in different
         # devices, in which case its better to use trainer's `prediction_step`

--- a/caikit_nlp/modules/text_generation/text_generation_local.py
+++ b/caikit_nlp/modules/text_generation/text_generation_local.py
@@ -110,7 +110,9 @@ class TextGeneration(ModuleBase):
         self._sep_token = sep_token
         self._eos_token = eos_token
         self._pad_token = pad_token
-        self.training_metadata = training_metadata
+        self.training_metadata = (
+            training_metadata if training_metadata is not None else {}
+        )
 
     # pylint: disable=duplicate-code
     def __del__(self):

--- a/caikit_nlp/resources/pretrained_model/base.py
+++ b/caikit_nlp/resources/pretrained_model/base.py
@@ -46,15 +46,27 @@ from transformers.trainer_utils import EvalPrediction
 # Local
 from ...data_model import GenerationTrainRecord, PromptOutputModelType
 from ...toolkit.data_type_utils import get_torch_dtype, str_to_torch_dtype
+from ...toolkit.trainer_utils import log_step
 
 log = alog.use_channel("HFRBAS")
 error = error_handler.get(log)
 
 
 class LoggingTrainer(Trainer):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.training_loss_history = []
+
+    def log(self, logs: Dict[str, float]) -> None:
+        """
+        Log `logs` on the various objects watching training.
+
+        Subclass and override this method to inject custom behavior.
+
+        Args:
+            logs (`Dict[str, float]`):
+                The values to log.
+        """
+        self.state = log_step(self.state, logs)
+        self.control = self.callback_handler.on_log(self.args, self.state, self.control, logs)
+
 
 class PretrainedModelBase(ABC, ModuleBase):
     """Common abstractions and requirements for pretrained model resources"""

--- a/caikit_nlp/resources/pretrained_model/base.py
+++ b/caikit_nlp/resources/pretrained_model/base.py
@@ -18,18 +18,15 @@ from collections.abc import Mapping
 from typing import Callable, Dict, List, Optional, Tuple, Type, Union
 import json
 import os
-from torch import nn
 
 # Third Party
-from torch.utils.data import Dataset, IterableDataset
+from torch.utils.data import IterableDataset
 from transformers import (
     AutoTokenizer,
-    DataCollator,
     DataCollatorWithPadding,
     Trainer,
     TrainingArguments,
 )
-from transformers.modeling_utils import PreTrainedModel
 from transformers.models.auto.auto_factory import _BaseAutoModelClass
 import torch
 
@@ -39,9 +36,6 @@ from caikit.core.data_model import DataStream
 from caikit.core.modules import ModuleBase, ModuleConfig, ModuleSaver
 from caikit.core.toolkit import error_handler
 import alog
-from transformers.tokenization_utils_base import PreTrainedTokenizerBase
-from transformers.trainer_callback import TrainerCallback
-from transformers.trainer_utils import EvalPrediction
 
 # Local
 from ...data_model import GenerationTrainRecord, PromptOutputModelType
@@ -53,7 +47,6 @@ error = error_handler.get(log)
 
 
 class LoggingTrainer(Trainer):
-
     def log(self, logs: Dict[str, float]) -> None:
         """
         Log `logs` on the various objects watching training.
@@ -65,7 +58,9 @@ class LoggingTrainer(Trainer):
                 The values to log.
         """
         self.state = log_step(self.state, logs)
-        self.control = self.callback_handler.on_log(self.args, self.state, self.control, logs)
+        self.control = self.callback_handler.on_log(
+            self.args, self.state, self.control, logs
+        )
 
 
 class PretrainedModelBase(ABC, ModuleBase):

--- a/caikit_nlp/resources/pretrained_model/hf_auto_seq2seq_lm.py
+++ b/caikit_nlp/resources/pretrained_model/hf_auto_seq2seq_lm.py
@@ -15,9 +15,7 @@
 Huggingface auto causal LM resource type
 """
 # Standard
-import os
 from collections.abc import Mapping
-from datetime import datetime
 from typing import Dict, List, Union
 
 # Third Party
@@ -29,7 +27,6 @@ from transformers import (
     Seq2SeqTrainingArguments,
 )
 from transformers.models.auto import modeling_auto
-import torch
 
 # First Party
 from caikit.core.modules import module
@@ -49,7 +46,6 @@ IGNORE_ID = -100
 
 
 class LoggingTrainer(Seq2SeqTrainer):
-
     def log(self, logs: Dict[str, float]) -> None:
         """
         Log `logs` on the various objects watching training.
@@ -61,7 +57,10 @@ class LoggingTrainer(Seq2SeqTrainer):
                 The values to log.
         """
         self.state = log_step(self.state, logs)
-        self.control = self.callback_handler.on_log(self.args, self.state, self.control, logs)
+        self.control = self.callback_handler.on_log(
+            self.args, self.state, self.control, logs
+        )
+
 
 @module(
     id="6759e891-287b-405b-bd8b-54a4a4d51c25",

--- a/caikit_nlp/toolkit/trainer_utils.py
+++ b/caikit_nlp/toolkit/trainer_utils.py
@@ -1,0 +1,60 @@
+# Copyright The Caikit Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Contains toolkit functionality for huggingface Trainer"""
+# Standard
+from datetime import datetime
+
+# First Party
+import alog
+
+# Third Party
+import torch
+
+log = alog.use_channel("TRNR_UTILS")
+
+def log_step(state, logs):
+    if state.epoch is not None:
+        logs["epoch"] = round(state.epoch, 2)
+
+
+    # Get Rank
+    if torch.distributed.is_initialized():
+        rank = torch.distributed.get_rank()
+    else:
+        rank = 0
+
+    if "loss" in logs:
+        if state.epoch is not None:
+            logs["epoch"] = round(state.epoch, 2)
+
+        log.debug(
+            "process rank: {} loss: {} step: {}".format(
+                rank,
+                float(logs['loss']),
+                state.global_step
+            )
+
+        )
+        output =  {
+                "epoch": float(logs["epoch"]),
+                "step": state.global_step,
+                "value": float(logs["loss"]),
+                "timestamp": datetime.isoformat(datetime.now()),
+            }
+        state.log_history.append(output)
+    else:
+        output = {**logs, **{"step": state.global_step}}
+        state.log_history.append(output)
+
+    return state

--- a/caikit_nlp/toolkit/trainer_utils.py
+++ b/caikit_nlp/toolkit/trainer_utils.py
@@ -15,18 +15,18 @@
 # Standard
 from datetime import datetime
 
-# First Party
-import alog
-
 # Third Party
 import torch
 
+# First Party
+import alog
+
 log = alog.use_channel("TRNR_UTILS")
+
 
 def log_step(state, logs):
     if state.epoch is not None:
         logs["epoch"] = round(state.epoch, 2)
-
 
     # Get Rank
     if torch.distributed.is_initialized():
@@ -40,18 +40,15 @@ def log_step(state, logs):
 
         log.debug(
             "process rank: {} loss: {} step: {}".format(
-                rank,
-                float(logs['loss']),
-                state.global_step
+                rank, float(logs["loss"]), state.global_step
             )
-
         )
-        output =  {
-                "epoch": float(logs["epoch"]),
-                "step": state.global_step,
-                "value": float(logs["loss"]),
-                "timestamp": datetime.isoformat(datetime.now()),
-            }
+        output = {
+            "epoch": float(logs["epoch"]),
+            "step": state.global_step,
+            "value": float(logs["loss"]),
+            "timestamp": datetime.isoformat(datetime.now()),
+        }
         state.log_history.append(output)
     else:
         output = {**logs, **{"step": state.global_step}}

--- a/examples/run_fine_tuning.py
+++ b/examples/run_fine_tuning.py
@@ -344,7 +344,7 @@ if __name__ == "__main__":
     sample_text = "summarize: The Inflation Reduction Act lowers prescription drug costs, health care costs, and energy costs. It's the most aggressive action on tackling the climate crisis in American history, which will lift up American workers and create good-paying, union jobs across the country. It'll lower the deficit and ask the ultra-wealthy and corporations to pay their fair share. And no one making under $400,000 per year will pay a penny more in taxes."
     prediction_results = model.run(sample_text)
 
-    # print("Generated text: ", prediction_results)
+    print("Generated text: ", prediction_results)
 
     # Saving model
     model.save(args.output_dir)

--- a/examples/run_fine_tuning.py
+++ b/examples/run_fine_tuning.py
@@ -344,7 +344,7 @@ if __name__ == "__main__":
     sample_text = "summarize: The Inflation Reduction Act lowers prescription drug costs, health care costs, and energy costs. It's the most aggressive action on tackling the climate crisis in American history, which will lift up American workers and create good-paying, union jobs across the country. It'll lower the deficit and ask the ultra-wealthy and corporations to pay their fair share. And no one making under $400,000 per year will pay a penny more in taxes."
     prediction_results = model.run(sample_text)
 
-    print("Generated text: ", prediction_results)
+    # print("Generated text: ", prediction_results)
 
     # Saving model
     model.save(args.output_dir)

--- a/tests/modules/text_generation/test_peft_prompt_tuning.py
+++ b/tests/modules/text_generation/test_peft_prompt_tuning.py
@@ -69,12 +69,12 @@ def test_save_log_loss_file(causal_lm_dummy_model):
     """Ensure saving a model saves the log loss file"""
     with tempfile.TemporaryDirectory() as model_dir:
         causal_lm_dummy_model.save(model_dir, save_base_model=False)
-        assert os.path.isfile(
-            os.path.join(
+        file_path = os.path.join(
                 model_dir,
                 caikit_nlp.modules.text_generation.peft_prompt_tuning.TRAINING_LOSS_LOG_FILENAME,
             )
-        )
+
+        assert os.path.isfile(file_path)
 
 
 def test_run_model(causal_lm_dummy_model):

--- a/tests/modules/text_generation/test_peft_prompt_tuning.py
+++ b/tests/modules/text_generation/test_peft_prompt_tuning.py
@@ -70,9 +70,9 @@ def test_save_log_loss_file(causal_lm_dummy_model):
     with tempfile.TemporaryDirectory() as model_dir:
         causal_lm_dummy_model.save(model_dir, save_base_model=False)
         file_path = os.path.join(
-                model_dir,
-                caikit_nlp.modules.text_generation.peft_prompt_tuning.TRAINING_LOSS_LOG_FILENAME,
-            )
+            model_dir,
+            caikit_nlp.modules.text_generation.peft_prompt_tuning.TRAINING_LOSS_LOG_FILENAME,
+        )
 
         assert os.path.isfile(file_path)
 


### PR DESCRIPTION
### Changes
- Update loss logging mechanism to log per step.
    - NOTE: The definition of step changes depending on how the training logic is implemented and if we are using `gradient_accumulation`. In case of huggingface trainer with gradient accumulation greater than 1, the definition of step becomes when the gradients are updated, which would be at every gradient accumulation step. 
- Update prompt tuning to use step wise gradient logic
- Add utility function for trainers to use for logging 
- Extend Trainer class for both base resource and seq2seq resource to override the `log` function
- Add loss logging functionality for fine-tuning module, similar to prompt tuning.


### Test

Produces following logs in `training_logs.jsonl` for fine-tuning:
```
{"name": "loss", "data": {"epoch": 0.01, "step": 1, "value": 3.9274, "timestamp": "2023-09-26T19:25:18.737364"}}
{"name": "loss", "data": {"epoch": 0.01, "step": 2, "value": 4.4904, "timestamp": "2023-09-26T19:25:19.316729"}}
...
```