### PR TITLE
use arg use_cpu instead of no_cuda

### DIFF
--- a/caikit_nlp/modules/text_generation/text_generation_local.py
+++ b/caikit_nlp/modules/text_generation/text_generation_local.py
@@ -361,7 +361,7 @@ class TextGeneration(ModuleBase):
                 "weight_decay": 0.01,
                 "save_total_limit": 3,
                 "push_to_hub": False,
-                "no_cuda": not torch.cuda.is_available(),  # Default
+                "use_cpu": not torch.cuda.is_available(),  # Default
                 "remove_unused_columns": True,
                 "dataloader_pin_memory": False,
                 "gradient_accumulation_steps": accumulate_steps,


### PR DESCRIPTION
`no_cuda` is a deprecated argument; the new arg is `use_cpu`.