### PR TITLE
proposal: use setuptools/setuptools_scm for building

### DIFF
--- a/.github/workflows/publish-library.yml
+++ b/.github/workflows/publish-library.yml
@@ -25,12 +25,11 @@ jobs:
       - uses: actions/checkout@v3
       - name: Set up Python
         uses: actions/setup-python@v3
-      - name: Release
-        env:
-          FLIT_PASSWORD: ${{ secrets.PYPI_TOKEN }}
+      - name: Build and check package
         run: |
-          pip install tox
-          RELEASE_VERSION=${GITHUB_REF#refs/*/}
-          RELEASE_VERSION=${RELEASE_VERSION#v*}
-          sed -i "s/^version = .*/version = \"${RELEASE_VERSION}\"/" pyproject.toml
-          tox -e publish
+          tox -e build,twinecheck
+      - name: Upload package
+        if: github.event_name == 'release'
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.PYPI_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -166,3 +166,4 @@ prompt_prefixes
 sample_prompt
 transformers_cache
 generated_interfaces
+/caikit_nlp/_version.py

--- a/caikit_nlp/__init__.py
+++ b/caikit_nlp/__init__.py
@@ -29,6 +29,7 @@ from .config import *
 from .data_model import *
 from .modules import *
 from .resources import *
+from .version import __version__, __version_tuple__
 
 # Configure the library with library-specific configuration file
 CONFIG_PATH = os.path.realpath(

--- a/caikit_nlp/version.py
+++ b/caikit_nlp/version.py
@@ -1,0 +1,7 @@
+# pylint: disable=unused-import
+try:
+    # Local
+    from ._version import __version__, __version_tuple__
+except ImportError:
+    __version__ = "unknown"
+    version_tuple = (0, 0, __version__)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ dependencies = [
 packages = ["caikit_nlp"]
 
 [tool.setuptools_scm]
+version_file = "caikit_nlp/_version.py"
 
 [project.urls]
 Source = "https://github.com/caikit/caikit-nlp"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,11 +1,11 @@
 [build-system]
-requires = ["flit_core >=3.2,<4"]
-build-backend = "flit_core.buildapi"
+requires = [
+    "setuptools>=60",
+    "setuptools-scm>=8.0"]
 
 [project]
 name = "caikit-nlp"
-# Not the actual current version: overwritten by CI
-version = "0.0.1"
+dynamic = ["version"]
 description = "Caikit NLP"
 license = {text = "Apache-2.0"}
 readme = "README.md"
@@ -34,6 +34,11 @@ dependencies = [
     # pypi
     "peft@git+https://github.com/huggingface/peft.git#8c17d556a8fe9522e10d73d7bd3fad46a6ecae14"
 ]
+
+[tool.setuptools]
+packages = ["caikit_nlp"]
+
+[tool.setuptools_scm]
 
 [project.urls]
 Source = "https://github.com/caikit/caikit-nlp"

--- a/tox.ini
+++ b/tox.ini
@@ -34,21 +34,17 @@ description = lint with pylint
 deps = pylint>=2.16.2,<3.0
 commands = pylint caikit_nlp
 
-[testenv:publish]
-description = publish wheel to pypi
-deps = flit==3.8
-passenv =
-    FLIT_PASSWORD
-setenv =
-    FLIT_USERNAME = __token__
-commands = flit publish
-skip_install = True
-
 [testenv:build]
 description = build wheel
-deps = flit==3.8
-passenv =
-    FLIT_PASSWORD
-setenv =
-    FLIT_USERNAME = __token__
-commands = flit build
+deps =
+    build
+    setuptools
+commands = python -m build
+skip_install = True
+
+[testenv:twinecheck]
+description = check wheel
+deps =
+    twine
+commands = twine check dist/*
+skip_install = True


### PR DESCRIPTION
This PR changes the build system from `flit` to `setuptools`+[`setuptools_scm`](https://github.com/pypa/setuptools_scm/). The main driver behind this PR is to simplify development by having `setuptools_scm` automatically set the module version at build/install time instead of having a fixed `0.0.1` version replaced by CI.

Another advantage of using `setuptools_scm` is to have proper versions reported when using editable installs, avoiding version requirements warnings/errors.

This also adds the possibility of using `caikit_nlp.__version__`  (or `__version_tuple__`) to check  the module version at runtime