### PR TITLE
Resync inf params tgis

### DIFF
--- a/caikit_nlp/modules/text_generation/peft_prompt_tuning.py
+++ b/caikit_nlp/modules/text_generation/peft_prompt_tuning.py
@@ -296,7 +296,7 @@ class PeftPromptTuning(ModuleBase):
         accumulate_steps: Optional[int] = 32,
         torch_dtype: Optional[str] = None,  # TODO: Optional[Union[torch.dtype, str]]
         silence_progress_bars: Optional[bool] = True,
-        random_seed: int = RANDOM_SEED,
+        seed: int = RANDOM_SEED,
         **kwargs,
     ) -> "PeftPromptTuning":
         """Run prompt tuning (vanilla or MPT) through PEFT on a CausalLM or Seq2seq model
@@ -342,7 +342,7 @@ class PeftPromptTuning(ModuleBase):
                 underpinning the resource will be converted in place to the correct torch dtype.
             silence_progress_bars: bool
                 Silences TQDM progress bars at train time. Default: True.
-            random_seed: int
+            seed: int
                 Integer to be used as random seed for training.
         Returns:
             PeftPromptTuning
@@ -350,10 +350,10 @@ class PeftPromptTuning(ModuleBase):
         """
 
         # Configure random seed
-        transformers.set_seed(random_seed)
+        transformers.set_seed(seed)
         # NOTE: Following can be uncommented to allow full determinism
         # but it can have impact on performance.
-        # transformers.enable_full_determinism(random_seed)
+        # transformers.enable_full_determinism(seed)
 
         # HACK - These things can't be passed through the train API currently
 

--- a/caikit_nlp/toolkit/text_generation/tgis_utils.py
+++ b/caikit_nlp/toolkit/text_generation/tgis_utils.py
@@ -125,12 +125,12 @@ def validate_inf_params(
     )
 
     error.value_check(
-        "<NLP28185346E>", top_p > 0.0 and top_p <= 1.0, "top_p must be > 0.0 and <= 1.0"
+        "<NLP28185346E>", top_p >= 0.0 and top_p <= 1.0, "top_p must be >= 0.0 and <= 1.0"
     )
 
     error.value_check("<NLP28185347E>", top_k >= 0, "top_k must be strictly positive")
 
-    error.value_check("<NLP28185348E>", typical_p <= 1.0, "typical_p must be <= 1.0")
+    error.value_check("<NLP28185348E>", typical_p < 1.0, "typical_p must be < 1.0")
 
     error.value_check(
         "<NLP28185349E>", repetition_penalty > 0.0, "repetition_penalty must be > 0.0"


### PR DESCRIPTION
### Changes
- `top_p` to allow `0` value in sync with TGIS 
- `typical_p` to not allow `1.0` value in sync with TGIS
- change `random_seed` to `seed` for `.train` function to be in `sync` with inference time parameter 