### PR TITLE
pyproject: use setuptools' automatic discovery

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,8 +35,10 @@ dependencies = [
     "peft@git+https://github.com/huggingface/peft.git#8c17d556a8fe9522e10d73d7bd3fad46a6ecae14"
 ]
 
-[tool.setuptools]
-packages = ["caikit_nlp"]
+[tool.setuptools.packages.find]
+exclude = ["tests", "tests.*"]
+namespaces = false
+
 
 [tool.setuptools_scm]
 version_file = "caikit_nlp/_version.py"


### PR DESCRIPTION
By not explicitly defining packages, setuptools will automatically find all packages using the flat-layout strategy.
    
This also prevents the following warnings to be printed when building using `python -m build`:
```
 _Warning: Package 'caikit_nlp.toolkit' is absent from the `packages` configuration.
```
  
  