### PR TITLE
tox: run pytest with --durations flag to list tests run time

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -15,7 +15,7 @@ passenv =
     LOG_FORMATTER
     LOG_THREAD_ID
     LOG_CHANNEL_WIDTH
-commands = pytest --cov=caikit_nlp --cov-report=term --cov-report=html {posargs:tests}
+commands = pytest --durations=42 --cov=caikit_nlp --cov-report=term --cov-report=html {posargs:tests}
 
 ; Unclear: We probably want to test wheel packaging
 ; But! tox will fail when this is set and _any_ interpreter is missing


### PR DESCRIPTION
By passing `--durations`, pytest reports the longest test run times.

Here's the top 5:
```
78.01s call     tests/model_management/test_tgis_auto_finder.py::test_bad_tgis_connection
4.23s call     tests/modules/text_generation/test_text_generation_tgis.py::test_local_train_load_tgis
3.31s call     tests/modules/text_generation/test_text_generation_local.py::test_train_model_save_and_load
1.86s call     tests/modules/text_generation/test_text_generation_local.py::test_train_model_seq2seq
1.75s call     tests/modules/text_generation/test_peft_prompt_tuning.py::test_run_model
```

It's probably worth it to add a timeout to `test_bad_tgis_connection` to avoid spending so much time there.