### PR TITLE
:goal_net: Disallow empty train streams

### DIFF
--- a/caikit_nlp/modules/text_generation/peft_prompt_tuning.py
+++ b/caikit_nlp/modules/text_generation/peft_prompt_tuning.py
@@ -345,6 +345,7 @@ class PeftPromptTuning(ModuleBase):
             PeftPromptTuning
                 Instance of this class with tuned prompt vectors.
         """
+        error.value_check("<NLP46653367E>", len(train_stream) > 0, "train_stream cannot be empty")
 
         # Configure random seed
         transformers.set_seed(seed)
@@ -388,6 +389,8 @@ class PeftPromptTuning(ModuleBase):
 
         train_stream = train_stream.map(convert_to_generation_record)
         if val_stream:
+            error.value_check("<NLP63201425E>", len(val_stream) > 0, "val_stream cannot be empty")
+
             val_stream = val_stream.map(convert_to_generation_record)
 
         # Convert our datastreams -> data loaders by disguising them as PyTorch iterable datasets

--- a/caikit_nlp/modules/text_generation/peft_prompt_tuning.py
+++ b/caikit_nlp/modules/text_generation/peft_prompt_tuning.py
@@ -345,7 +345,9 @@ class PeftPromptTuning(ModuleBase):
             PeftPromptTuning
                 Instance of this class with tuned prompt vectors.
         """
-        error.value_check("<NLP46653367E>", len(train_stream) > 0, "train_stream cannot be empty")
+        error.value_check(
+            "<NLP46653367E>", len(train_stream) > 0, "train_stream cannot be empty"
+        )
 
         # Configure random seed
         transformers.set_seed(seed)
@@ -389,7 +391,9 @@ class PeftPromptTuning(ModuleBase):
 
         train_stream = train_stream.map(convert_to_generation_record)
         if val_stream:
-            error.value_check("<NLP63201425E>", len(val_stream) > 0, "val_stream cannot be empty")
+            error.value_check(
+                "<NLP63201425E>", len(val_stream) > 0, "val_stream cannot be empty"
+            )
 
             val_stream = val_stream.map(convert_to_generation_record)
 

--- a/caikit_nlp/modules/text_generation/text_generation_local.py
+++ b/caikit_nlp/modules/text_generation/text_generation_local.py
@@ -224,7 +224,9 @@ class TextGeneration(ModuleBase):
             TextGeneration
                 Instance of this class with fine-tuned models.
         """
-        error.value_check("<NLP96406893E>", len(train_stream) > 0, "train_stream cannot be empty")
+        error.value_check(
+            "<NLP96406893E>", len(train_stream) > 0, "train_stream cannot be empty"
+        )
 
         torch_dtype = get_torch_dtype(torch_dtype)
 

--- a/caikit_nlp/modules/text_generation/text_generation_local.py
+++ b/caikit_nlp/modules/text_generation/text_generation_local.py
@@ -224,6 +224,7 @@ class TextGeneration(ModuleBase):
             TextGeneration
                 Instance of this class with fine-tuned models.
         """
+        error.value_check("<NLP96406893E>", len(train_stream) > 0, "train_stream cannot be empty")
 
         torch_dtype = get_torch_dtype(torch_dtype)
 

--- a/tests/fixtures/__init__.py
+++ b/tests/fixtures/__init__.py
@@ -115,11 +115,13 @@ def causal_lm_train_kwargs():
         "base_model": HFAutoCausalLM.bootstrap(
             model_name=CAUSAL_LM_MODEL, tokenizer_name=CAUSAL_LM_MODEL
         ),
-        "train_stream": caikit.core.data_model.DataStream.from_iterable([
-            caikit_nlp.data_model.GenerationTrainRecord(
-                input="@foo what a cute dog!", output="no complaint"
-            ),
-        ]),
+        "train_stream": caikit.core.data_model.DataStream.from_iterable(
+            [
+                caikit_nlp.data_model.GenerationTrainRecord(
+                    input="@foo what a cute dog!", output="no complaint"
+                ),
+            ]
+        ),
         "num_epochs": 0,
         "tuning_config": caikit_nlp.data_model.TuningConfig(
             num_virtual_tokens=8, prompt_tuning_init_text="hello world"
@@ -153,11 +155,13 @@ def seq2seq_lm_train_kwargs():
         "base_model": HFAutoSeq2SeqLM.bootstrap(
             model_name=SEQ2SEQ_LM_MODEL, tokenizer_name=SEQ2SEQ_LM_MODEL
         ),
-        "train_stream": caikit.core.data_model.DataStream.from_iterable([
-            caikit_nlp.data_model.GenerationTrainRecord(
-                input="@foo what a cute dog!", output="no complaint"
-            ),
-        ]),
+        "train_stream": caikit.core.data_model.DataStream.from_iterable(
+            [
+                caikit_nlp.data_model.GenerationTrainRecord(
+                    input="@foo what a cute dog!", output="no complaint"
+                ),
+            ]
+        ),
         "num_epochs": 0,
         "tuning_config": caikit_nlp.data_model.TuningConfig(
             num_virtual_tokens=16, prompt_tuning_init_text="hello world"

--- a/tests/fixtures/__init__.py
+++ b/tests/fixtures/__init__.py
@@ -115,7 +115,11 @@ def causal_lm_train_kwargs():
         "base_model": HFAutoCausalLM.bootstrap(
             model_name=CAUSAL_LM_MODEL, tokenizer_name=CAUSAL_LM_MODEL
         ),
-        "train_stream": caikit.core.data_model.DataStream.from_iterable([]),
+        "train_stream": caikit.core.data_model.DataStream.from_iterable([
+            caikit_nlp.data_model.GenerationTrainRecord(
+                input="@foo what a cute dog!", output="no complaint"
+            ),
+        ]),
         "num_epochs": 0,
         "tuning_config": caikit_nlp.data_model.TuningConfig(
             num_virtual_tokens=8, prompt_tuning_init_text="hello world"
@@ -149,7 +153,11 @@ def seq2seq_lm_train_kwargs():
         "base_model": HFAutoSeq2SeqLM.bootstrap(
             model_name=SEQ2SEQ_LM_MODEL, tokenizer_name=SEQ2SEQ_LM_MODEL
         ),
-        "train_stream": caikit.core.data_model.DataStream.from_iterable([]),
+        "train_stream": caikit.core.data_model.DataStream.from_iterable([
+            caikit_nlp.data_model.GenerationTrainRecord(
+                input="@foo what a cute dog!", output="no complaint"
+            ),
+        ]),
         "num_epochs": 0,
         "tuning_config": caikit_nlp.data_model.TuningConfig(
             num_virtual_tokens=16, prompt_tuning_init_text="hello world"

--- a/tests/modules/text_generation/test_peft_prompt_tuning.py
+++ b/tests/modules/text_generation/test_peft_prompt_tuning.py
@@ -258,6 +258,19 @@ def test_prompt_output_types(causal_lm_train_kwargs):
     assert model
 
 
+def test_error_empty_stream(causal_lm_train_kwargs):
+    patch_kwargs = {
+        "num_epochs": 1,
+        "verbalizer": "Tweet text : {{input}} Label : ",
+        "train_stream": caikit.core.data_model.DataStream.from_iterable([]),
+    }
+    causal_lm_train_kwargs.update(patch_kwargs)
+    with pytest.raises(ValueError):
+        caikit_nlp.modules.text_generation.PeftPromptTuning.train(
+            **causal_lm_train_kwargs
+        )
+
+
 ### Implementation details
 # These tests can probably be removed and tested directly through .save() once
 # full seq2seq support is completed and verified.


### PR DESCRIPTION
Re-creation of #223 - this had to be reverted because of https://github.com/caikit/caikit/issues/524, which has since been addressed via https://github.com/caikit/caikit/pull/553 and released in caikit 0.23.1

Addresses https://github.com/caikit/caikit-nlp/issues/214