### PR TITLE
Add preserve input text inference

### DIFF
--- a/caikit_nlp/modules/text_generation/peft_prompt_tuning.py
+++ b/caikit_nlp/modules/text_generation/peft_prompt_tuning.py
@@ -170,11 +170,16 @@ class PeftPromptTuning(ModuleBase):
         ] = None,
         stop_sequences: Optional[List[str]] = None,
         seed: Optional[np.uint64] = None,
+        preserve_input_text: bool = True,
     ) -> GeneratedTextResult:
         f"""
         Run the full text generation model.
         Args:
             {GENERATE_FUNCTION_ARGS}
+            preserve_input_text: bool
+                Applicable only to Causal LLMs.
+                Whether or not the source string should be contained in the generated output,
+                e.g., as a prefix. Default True. (Source string will appear as prefix)
         Returns:
             GeneratedTextResult
                 Generated text result produced by PEFT / Transformers.
@@ -201,6 +206,8 @@ class PeftPromptTuning(ModuleBase):
             max_time=max_time,
             exponential_decay_length_penalty=exponential_decay_length_penalty,
             stop_sequences=stop_sequences,
+            preserve_input_text=preserve_input_text,
+            task_type=self.task_type,
         )
 
     # NOTE: We need to disable wip decorator here otherwise we get issues in

--- a/caikit_nlp/modules/text_generation/text_generation_local.py
+++ b/caikit_nlp/modules/text_generation/text_generation_local.py
@@ -531,13 +531,17 @@ class TextGeneration(ModuleBase):
         temperature: Optional[float] = None,
         repetition_penalty: Optional[float] = None,
         max_time: Optional[float] = None,
+        preserve_input_text: bool = True,
         **kwargs,
     ) -> GeneratedTextResult:
 
         f"""
         Run the full text generation model.
         Args:
-            {GENERATE_FUNCTION_ARGS}
+            {GENERATE_FUNCTION_ARGS},
+            preserve_input_text: bool
+                Whether or not the source string should be contained in the generated output,
+                e.g., as a prefix. Default True. (Source string will apprear as prefix)
         Returns:
             GeneratedTextResult
                 Generated text result produced by the model.
@@ -562,6 +566,7 @@ class TextGeneration(ModuleBase):
             temperature=temperature,
             repetition_penalty=repetition_penalty,
             max_time=max_time,
+            preserve_input_text=preserve_input_text,
             **kwargs,
         )
 

--- a/caikit_nlp/modules/text_generation/text_generation_local.py
+++ b/caikit_nlp/modules/text_generation/text_generation_local.py
@@ -540,8 +540,9 @@ class TextGeneration(ModuleBase):
         Args:
             {GENERATE_FUNCTION_ARGS},
             preserve_input_text: bool
+                Applicable only to Causal LLMs.
                 Whether or not the source string should be contained in the generated output,
-                e.g., as a prefix. Default True. (Source string will apprear as prefix)
+                e.g., as a prefix. Default True. (Source string will appear as prefix)
         Returns:
             GeneratedTextResult
                 Generated text result produced by the model.
@@ -567,6 +568,7 @@ class TextGeneration(ModuleBase):
             repetition_penalty=repetition_penalty,
             max_time=max_time,
             preserve_input_text=preserve_input_text,
+            task_type=self.model.TASK_TYPE,
             **kwargs,
         )
 

--- a/caikit_nlp/toolkit/text_generation/model_run_utils.py
+++ b/caikit_nlp/toolkit/text_generation/model_run_utils.py
@@ -152,6 +152,7 @@ def generate_text_func(
         Union[Tuple[int, float], ExponentialDecayLengthPenalty]
     ] = None,
     stop_sequences: Optional[List[str]] = None,
+    preserve_input_text: bool = True,
     **kwargs,
 ):
     """
@@ -164,6 +165,9 @@ def generate_text_func(
                 Caikit producer id associated with the module
             eos_token: str
                 End of sequence token to be used with generation
+            preserve_input_text: bool
+                Whether or not the source string should be contained in the generated output,
+                e.g., as a prefix. Default True. (Source string will apprear as prefix)
             {}
         Returns:
             GeneratedTextResult
@@ -235,6 +239,18 @@ def generate_text_func(
         for g in generate_ids
     ]
 
+    if preserve_input_text!=True:
+        prompt_length = len(
+                        tokenizer.decode(
+                            inputs["input_ids"][0],
+                            skip_special_tokens=True,
+                            clean_up_tokenization_spaces=True,
+                        )
+                    )
+        generated_text = preds[0][prompt_length:]
+    else:
+        generated_text = preds[0]
+
     if (eos_token and tokenizer.decode(generate_ids[0, -1].item()) == eos_token) or (
         generate_ids[0, -1] == tokenizer.eos_token_id
     ):
@@ -251,7 +267,7 @@ def generate_text_func(
 
     return GeneratedTextResult(
         generated_tokens=token_count,
-        generated_text=preds[0],
+        generated_text=generated_text,
         finish_reason=finish_reason,
         producer_id=producer_id,
         input_token_count=input_token_count,

--- a/tests/modules/text_generation/test_peft_prompt_tuning.py
+++ b/tests/modules/text_generation/test_peft_prompt_tuning.py
@@ -363,6 +363,19 @@ def test_run_truncate_tokens_0(causal_lm_dummy_model):
     assert isinstance(pred, GeneratedTextResult)
 
 
+def test_run_with_preserve_input_text(causal_lm_dummy_model):
+    """Ensure preserve input text removes input
+    from generated output when set to False"""
+    pred = causal_lm_dummy_model.run(
+        "This text doesn't matter", preserve_input_text=True
+    )
+    assert "This text doesn't matter" in pred.generated_text
+    pred = causal_lm_dummy_model.run(
+        "This text doesn't matter", preserve_input_text=False
+    )
+    assert "This text doesn't matter" not in pred.generated_text
+
+
 def test_run_sampling_param_ignored_greedy_decoding(causal_lm_dummy_model):
     """Ensure sampling parameter gets ignored when decoding method
     is set to GREEDY

--- a/tests/modules/text_generation/test_peft_prompt_tuning.py
+++ b/tests/modules/text_generation/test_peft_prompt_tuning.py
@@ -366,14 +366,11 @@ def test_run_truncate_tokens_0(causal_lm_dummy_model):
 def test_run_with_preserve_input_text(causal_lm_dummy_model):
     """Ensure preserve input text removes input
     from generated output when set to False"""
-    pred = causal_lm_dummy_model.run(
-        "This text doesn't matter", preserve_input_text=True
-    )
-    assert "This text doesn't matter" in pred.generated_text
-    pred = causal_lm_dummy_model.run(
-        "This text doesn't matter", preserve_input_text=False
-    )
-    assert "This text doesn't matter" not in pred.generated_text
+    input_text = "This text doesn't matter"
+    pred = causal_lm_dummy_model.run(input_text, preserve_input_text=True)
+    assert input_text in pred.generated_text
+    pred = causal_lm_dummy_model.run(input_text, preserve_input_text=False)
+    assert input_text not in pred.generated_text
 
 
 def test_run_sampling_param_ignored_greedy_decoding(causal_lm_dummy_model):

--- a/tests/toolkit/text_generation/test_model_run_utils.py
+++ b/tests/toolkit/text_generation/test_model_run_utils.py
@@ -46,7 +46,7 @@ def test_generate_text_func_serialization_json(
 
 
 @pytest.mark.parametrize("causal_model_fixture", ["causal_lm_dummy_model"])
-def test_generate_text_func_preserve_input(request, causal_model_fixture):
+def test_generate_text_func_preserve_input_causal_lm(request, causal_model_fixture):
     """For Causal LM task types, setting preserve_inout_text to True
     will result in input text in model prediction. Setting to False will
     strip the input text from model prediction.

--- a/tests/toolkit/text_generation/test_model_run_utils.py
+++ b/tests/toolkit/text_generation/test_model_run_utils.py
@@ -43,3 +43,65 @@ def test_generate_text_func_serialization_json(
 
     serialized = getattr(generated_text, serialization_method)()
     assert isinstance(serialized, expected_type)
+
+
+@pytest.mark.parametrize("causal_model_fixture", ["causal_lm_dummy_model"])
+def test_generate_text_func_preserve_input(request, causal_model_fixture):
+    """For Causal LM task types, setting preserve_inout_text to True
+    will result in input text in model prediction. Setting to False will
+    strip the input text from model prediction.
+    """
+    input_text = "What is the boiling point of liquid Nitrogen?"
+    causal_model = request.getfixturevalue(causal_model_fixture)
+    # assert type(causal_model.model) == False
+    generated_text = generate_text_func(
+        model=causal_model.model,
+        tokenizer=causal_model.tokenizer,
+        producer_id=ProducerId("TextGeneration", "0.1.0"),
+        eos_token="<\n>",
+        text=input_text,
+        preserve_input_text=True,
+        task_type="CAUSAL_LM",
+    )
+    assert input_text in generated_text.generated_text
+    generated_text = generate_text_func(
+        model=causal_model.model,
+        tokenizer=causal_model.tokenizer,
+        producer_id=ProducerId("TextGeneration", "0.1.0"),
+        eos_token="<\n>",
+        text=input_text,
+        preserve_input_text=False,
+        task_type="CAUSAL_LM",
+    )
+    assert input_text not in generated_text.generated_text
+
+
+@pytest.mark.parametrize("seq_model_fixture", ["seq2seq_lm_dummy_model"])
+def test_generate_text_func_preserve_input(request, seq_model_fixture):
+    """For Seq2Seq LM task types, setting preserve_inout_text to True
+    or False should not change predictions.
+    """
+    input_text = "What is the boiling point of liquid Nitrogen?"
+    seq_model = request.getfixturevalue(seq_model_fixture)
+    # assert type(causal_model.model) == False
+    generated_text = generate_text_func(
+        model=seq_model.model,
+        tokenizer=seq_model.tokenizer,
+        producer_id=ProducerId("TextGeneration", "0.1.0"),
+        eos_token="<\n>",
+        text=input_text,
+        preserve_input_text=True,
+        task_type="SEQ_2_SEQ_LM",
+    )
+    before_pred = generated_text.generated_text
+    generated_text = generate_text_func(
+        model=seq_model.model,
+        tokenizer=seq_model.tokenizer,
+        producer_id=ProducerId("TextGeneration", "0.1.0"),
+        eos_token="<\n>",
+        text=input_text,
+        preserve_input_text=False,
+        task_type="SEQ_2_SEQ_LM",
+    )
+    after_pred = generated_text.generated_text
+    assert before_pred == after_pred


### PR DESCRIPTION
for: https://github.com/caikit/caikit-nlp/issues/243

adds a flag to preserve or remove input text from output of CAUSAL models (**local inferencing** of prompt tuning and generation)

this will achieve functional parity with TGIS

The change will enable local evaluation of causal models without TGIS