### PR TITLE
Text Embedding: Add optimizations with PT2_COMPILE and/or IPEX

### DIFF
--- a/caikit_nlp/modules/text_embedding/embedding.py
+++ b/caikit_nlp/modules/text_embedding/embedding.py
@@ -75,35 +75,6 @@ except ModuleNotFoundError:
 # For testing env vars for values that mean false
 FALSY = ("no", "n", "false", "0", "f", "off")
 
-# When IPEX_OPTIMIZE is not false, attempt to import the library and use it.
-IPEX_OPTIMIZE = os.getenv("IPEX_OPTIMIZE", "false").lower() not in FALSY
-if IPEX_OPTIMIZE:
-    try:
-        ipex = importlib.import_module("intel_extension_for_pytorch")
-    except Exception as ie:  # pylint: disable=broad-exception-caught
-        # We don't require the module so catch, disable, log, proceed.
-        IPEX_OPTIMIZE = False
-        msg = (
-            f"IPEX_OPTIMIZE enabled in env, but skipping ipex.optimize() because "
-            f"import intel_extension_for_pytorch failed with exception: {ie}"
-        )
-        logger.warning(msg, exc_info=1)
-if IPEX_OPTIMIZE:
-    # Optionally use "xpu" (IPEX on GPU instead of IPEX on CPU)
-    USE_XPU = os.getenv("USE_XPU", "false").lower() not in FALSY
-    USE_MPS = False  # Don't use "mps" with IPEX.
-else:
-    USE_XPU = False  # We don't USE_XPU when we don't IPEX_OPTIMIZE
-    # Otherwise when USE_MPS is not false, use device "mps" if it is available
-    USE_MPS = (
-        os.getenv("USE_MPS", "false").lower() not in FALSY
-        and mps.is_built()
-        and mps.is_available()
-    )
-
-# torch.compile won't work everywhere, but when set we'll try it
-PT2_COMPILE = os.getenv("PT2_COMPILE", "false").lower() not in FALSY
-
 
 @module(
     "eeb12558-b4fa-4f34-a9fd-3f5890e9cd3f",
@@ -155,32 +126,83 @@ class EmbeddingModule(ModuleBase):
         artifacts_path = os.path.abspath(os.path.join(model_path, artifacts_path))
         error.dir_check("<NLP34197772E>", artifacts_path)
 
-        gpu = (
-            "xpu"
-            if USE_XPU
-            else "mps"
-            if USE_MPS
-            else "cuda"
-            if torch.cuda.is_available()
-            else None
-        )
-        model = SentenceTransformer(model_name_or_path=artifacts_path, device=gpu)
+        ipex = cls._get_ipex()
+        device = cls._select_device(ipex)
+        model = SentenceTransformer(model_name_or_path=artifacts_path, device=device)
+        if device is not None:
+            model.to(torch.device(device))
+        model = EmbeddingModule._optimize(model, ipex, device)
 
-        if gpu is not None:
-            model.to(torch.device(gpu))
-        model = cls._optimize(model)
+        # Validate model with any encode test (simple and hardcoded for now).
+        # This gets some of the first-time inference cost out of the way.
+        # This avoids using the tokenizer (for truncation) before it is ready.
+        model.encode("warmup")
+
         return cls(model)
 
     @staticmethod
-    def _optimize(model):
-        if IPEX_OPTIMIZE:
+    def _get_ipex():
+        """Get IPEX optimization library if enabled and available, else return False
+
+        Returns ipex library or False
+        """
+        ret = False
+
+        # Enabled by environment variable
+        # When IPEX_OPTIMIZE is not false, attempt to import the library and use it.
+        if os.getenv("IPEX_OPTIMIZE", "false").lower() not in FALSY:
+            try:
+                ret = importlib.import_module("intel_extension_for_pytorch")
+            except Exception as ie:  # pylint: disable=broad-exception-caught
+                # We don't require the module so catch, log, proceed to return False
+                msg = (
+                    f"IPEX_OPTIMIZE enabled in env, but skipping ipex.optimize() because "
+                    f"import intel_extension_for_pytorch failed with exception: {ie}"
+                )
+                logger.warning(msg, exc_info=1)
+
+        return ret
+
+    @staticmethod
+    def _select_device(use_ipex):
+        """Use environment variables and availability to determine the device to use"""
+        if use_ipex:
+            # If enabled, use "xpu" (IPEX on GPU instead of IPEX on CPU)
+            if os.getenv("USE_XPU", "false").lower() not in FALSY:
+                return "xpu"
+        elif (
+            os.getenv("USE_MPS", "false").lower() not in FALSY
+            and mps.is_built()
+            and mps.is_available()
+        ):
+            # Never use on ipex, but otherwise use mps if enabled and available
+            return "mps"
+
+        return "cuda" if torch.cuda.is_available() else None
+
+    @staticmethod
+    def _get_backend(use_ipex, use_device):
+        """Determine the backend to use for torch compile.
+
+        Considers global ipex if enabled first, next mps device, finally defaults.
+
+        Returns the backend for torch.compile()
+        """
+        if use_ipex:
+            return "ipex"
+        if use_device == "mps":
+            return mps
+        return "inductor"  # default backend
+
+    @staticmethod
+    def _optimize(model, ipex, device):
+
+        if ipex:
             model = ipex.optimize(model)
-            backend = "ipex"
-        elif USE_MPS:
-            backend = mps
-        else:
-            backend = "inductor"  # default backend
-        if PT2_COMPILE:
+
+        # torch.compile won't work everywhere, but when set we'll try it
+        if os.getenv("PT2_COMPILE", "false").lower() not in FALSY:
+            backend = EmbeddingModule._get_backend(ipex, device)
             try:
                 model = torch.compile(model, backend=backend, mode="max-autotune")
             except Exception as e:  # pylint: disable=broad-exception-caught

--- a/tests/modules/text_embedding/test_embedding.py
+++ b/tests/modules/text_embedding/test_embedding.py
@@ -7,6 +7,7 @@ import tempfile
 
 # Third Party
 from pytest import approx
+from torch.backends import mps
 import numpy as np
 import pytest
 
@@ -378,3 +379,55 @@ def test_run_sentence_similarities():
         assert len(scores) == len(SENTENCES)
         for score in scores:
             assert isinstance(score, float)
+
+
+@pytest.mark.parametrize(
+    "use_ipex, use_xpu, use_mps, expected",
+    [
+        (True, "true", "true", "xpu"),
+        (True, "true", "false", "xpu"),
+        (True, "false", "true", None),
+        (True, "false", "false", None),
+        (False, "false", "false", None),
+        (False, "true", "false", None),
+        (False, "false", "true", "mps"),
+        (False, "true", "true", "mps"),
+    ],
+)
+def test__select_device(use_ipex, use_xpu, use_mps, expected, monkeypatch):
+    monkeypatch.setenv("USE_XPU", use_xpu)
+    monkeypatch.setenv("USE_MPS", use_mps)
+    assert EmbeddingModule._select_device(use_ipex) == expected
+
+
+@pytest.mark.parametrize(
+    "use_ipex, use_device, expected",
+    [
+        (True, None, "ipex"),
+        (True, "mps", "ipex"),
+        (False, "mps", mps),
+        (False, None, "inductor"),
+    ],
+)
+def test__get_backend(use_ipex, use_device, expected):
+    assert EmbeddingModule._get_backend(use_ipex, use_device) == expected
+
+
+@pytest.mark.parametrize(
+    "use_ipex",
+    [None, 0, 1, "true", "True", "False", "false"],
+)
+def test__get_ipex(use_ipex, monkeypatch):
+    """Test that _get_ipex returns False instead of raising an exception.
+
+    Assumes that when running tests, we won't have IPEX installed.
+    """
+    monkeypatch.setenv("USE_IPEX", use_ipex)
+    assert not EmbeddingModule._get_ipex()
+
+
+def test__optimize(monkeypatch):
+    """Test that _optimize does nothing when disabled"""
+    fake = "fake model"  # Will be returned as-is
+    monkeypatch.setenv("PT2_COMPILE", "False")
+    assert fake == EmbeddingModule._optimize(fake, False, "bogus")

--- a/tests/modules/text_embedding/test_embedding.py
+++ b/tests/modules/text_embedding/test_embedding.py
@@ -415,24 +415,27 @@ def test__select_device(use_ipex, use_xpu, use_mps, expected, monkeypatch):
     [
         (True, None, "ipex"),
         (True, "mps", "ipex"),
-        (False, "mps", mps if mps.is_built() and mps.is_available() else "inductor"),
+        (False, "mps", mps),
         (False, None, "inductor"),
     ],
 )
 def test__get_backend(use_ipex, use_device, expected):
+    # Make the Mac MPS test work depending on availability
+    if expected == mps and not (mps.is_built() and mps.is_available()):
+        expected = "inductor"
     assert EmbeddingModule._get_backend(use_ipex, use_device) == expected
 
 
 @pytest.mark.parametrize(
     "use_ipex",
-    [None, 0, 1, "true", "True", "False", "false"],
+    [None, "true", "True", "False", "false"],
 )
 def test__get_ipex(use_ipex, monkeypatch):
     """Test that _get_ipex returns False instead of raising an exception.
 
     Assumes that when running tests, we won't have IPEX installed.
     """
-    monkeypatch.setenv("USE_IPEX", use_ipex)
+    monkeypatch.setenv("IPEX_OPTIMIZE", use_ipex)
     assert not EmbeddingModule._get_ipex()
 
 

--- a/tests/modules/text_embedding/test_embedding.py
+++ b/tests/modules/text_embedding/test_embedding.py
@@ -421,8 +421,6 @@ def test__select_device(use_ipex, use_xpu, use_mps, expected, monkeypatch):
 )
 def test__get_backend(use_ipex, use_device, expected):
     # Make the Mac MPS test work depending on availability
-    if expected == mps and not (mps.is_built() and mps.is_available()):
-        expected = "inductor"
     assert EmbeddingModule._get_backend(use_ipex, use_device) == expected
 
 

--- a/tests/modules/text_embedding/test_embedding.py
+++ b/tests/modules/text_embedding/test_embedding.py
@@ -390,8 +390,18 @@ def test_run_sentence_similarities():
         (True, "false", "false", None),
         (False, "false", "false", None),
         (False, "true", "false", None),
-        (False, "false", "true", "mps"),
-        (False, "true", "true", "mps"),
+        (
+            False,
+            "false",
+            "true",
+            "mps" if mps.is_built() and mps.is_available() else None,
+        ),
+        (
+            False,
+            "true",
+            "true",
+            "mps" if mps.is_built() and mps.is_available() else None,
+        ),
     ],
 )
 def test__select_device(use_ipex, use_xpu, use_mps, expected, monkeypatch):
@@ -405,7 +415,7 @@ def test__select_device(use_ipex, use_xpu, use_mps, expected, monkeypatch):
     [
         (True, None, "ipex"),
         (True, "mps", "ipex"),
-        (False, "mps", mps),
+        (False, "mps", mps if mps.is_built() and mps.is_available() else "inductor"),
         (False, None, "inductor"),
     ],
 )


### PR DESCRIPTION
Add flag to use pytorch compile and/or try IPEX.

To use IPEX:
1.  Install intel-extension-for-pytorch
2. Set env var USE_IPEX=true

Default is false.  If set to true, but the import fails, then a warning will be logged and USE_IPEX will be disabled.
Optionally, USE_XPU may be set to true to allow IPEX to use its xpu (only applies when IPEX is active).

USE_MPS has been added for GPU testing on Macbook (ignored when IPEX is used).

To invoke torch.compile() optimization, set the env var PT2_COMPILE=true.
torch.compile() is not available on all versions/platforms.  A warning message is logged if this is enabled and throws an exception.

