### PR TITLE
Text Embedding: Truncation allow or fail with optional parameter

### DIFF
--- a/caikit_nlp/modules/text_embedding/embedding.py
+++ b/caikit_nlp/modules/text_embedding/embedding.py
@@ -275,7 +275,7 @@ class EmbeddingModule(ModuleBase):
                 # decode the truncated input tokens back to text to be returned
                 ret.append(
                     self.model.tokenizer.decode(
-                        tokenized.input_ids[0], skip_special_tokens=True
+                        tokenized.input_ids[0], skip_special_tokens=False
                     )
                 )
 

--- a/tests/modules/text_embedding/test_embedding.py
+++ b/tests/modules/text_embedding/test_embedding.py
@@ -442,3 +442,38 @@ def test__optimize(monkeypatch):
     fake = "fake model"  # Will be returned as-is
     monkeypatch.setenv("PT2_COMPILE", "False")
     assert fake == EmbeddingModule._optimize(fake, False, "bogus")
+
+
+def test_no_truncation():
+    """These endpoints raise an error if truncation would happen."""
+
+    too_long = "hello " * 1000
+    ok = "hi "
+
+    model = BOOTSTRAPPED_MODEL
+
+    # embedding(s)
+    with pytest.raises(ValueError):
+        model.run_embedding(text=too_long)
+    with pytest.raises(ValueError):
+        model.run_embeddings(texts=[too_long])
+
+    # sentence similarity(ies) test both source_sentence and sentences
+    with pytest.raises(ValueError):
+        model.run_sentence_similarity(source_sentence=too_long, sentences=[ok])
+    with pytest.raises(ValueError):
+        model.run_sentence_similarity(source_sentence=ok, sentences=[too_long])
+    with pytest.raises(ValueError):
+        model.run_sentence_similarities(source_sentences=[too_long], sentences=[ok])
+    with pytest.raises(ValueError):
+        model.run_sentence_similarities(source_sentences=[ok], sentences=[too_long])
+
+    # reranker(s) test both source_sentence and sentences
+    with pytest.raises(ValueError):
+        model.run_rerank_query(query=too_long, documents=[{"text": ok}])
+    with pytest.raises(ValueError):
+        model.run_rerank_query(query=ok, documents=[{"text": too_long}])
+    with pytest.raises(ValueError):
+        model.run_rerank_queries(queries=[too_long], documents=[{"text": ok}])
+    with pytest.raises(ValueError):
+        model.run_rerank_queries(queries=[ok], documents=[{"text": too_long}])

--- a/tests/modules/text_embedding/test_embedding.py
+++ b/tests/modules/text_embedding/test_embedding.py
@@ -444,8 +444,56 @@ def test__optimize(monkeypatch):
     assert fake == EmbeddingModule._optimize(fake, False, "bogus")
 
 
-def test_no_truncation():
-    """These endpoints raise an error if truncation would happen."""
+@pytest.mark.parametrize(
+    "truncate_input_tokens, expected_len", [(99, 205), (333, 673), (-1, 1022)]
+)
+def test__truncate_input_tokens(truncate_input_tokens, expected_len):
+    model = BOOTSTRAPPED_MODEL
+    model_max = model.model.max_seq_length
+
+    too_long = "x " * (model_max - 1)  # This will go over
+    actual = model._truncate_input_tokens(
+        truncate_input_tokens=truncate_input_tokens, texts=[too_long]
+    )[0]
+
+    assert len(actual) == expected_len
+
+
+@pytest.mark.parametrize("truncate_input_tokens", [0, 513])
+def test__truncate_input_tokens_raises(truncate_input_tokens):
+    model = BOOTSTRAPPED_MODEL
+    model_max = model.model.max_seq_length
+
+    too_long = "x " * (model_max - 1)  # This will go over
+    with pytest.raises(ValueError):
+        model._truncate_input_tokens(
+            truncate_input_tokens=truncate_input_tokens, texts=[too_long]
+        )
+
+
+def test_not_too_many_tokens():
+    """Happy path for the endpoints using text that is not too many tokens."""
+
+    model = BOOTSTRAPPED_MODEL
+    model_max = model.model.max_seq_length
+
+    ok = "x " * (model_max - 2)  # Subtract 2 for begin/end tokens
+
+    # embedding(s)
+    model.run_embedding(text=ok)
+    model.run_embeddings(texts=[ok])
+
+    # sentence similarity(ies) test both source_sentence and sentences
+    model.run_sentence_similarity(source_sentence=ok, sentences=[ok])
+    model.run_sentence_similarities(source_sentences=[ok], sentences=[ok])
+
+    # reranker test both query and document text
+    model.run_rerank_query(query=ok, documents=[{"text": ok}])
+    model.run_rerank_queries(queries=[ok], documents=[{"text": ok}])
+
+
+def test_too_many_tokens_default():
+    """These endpoints raise an error when truncation would happen."""
 
     model = BOOTSTRAPPED_MODEL
     model_max = model.model.max_seq_length
@@ -454,35 +502,171 @@ def test_no_truncation():
     too_long = "x " * (model_max - 1)  # This will go over
 
     # embedding(s)
-    model.run_embedding(text=ok)
     with pytest.raises(ValueError):
         model.run_embedding(text=too_long)
-    model.run_embeddings(texts=[ok])
     with pytest.raises(ValueError):
         model.run_embeddings(texts=[too_long])
 
     # sentence similarity(ies) test both source_sentence and sentences
-    model.run_sentence_similarity(source_sentence=ok, sentences=[ok])
     with pytest.raises(ValueError):
         model.run_sentence_similarity(source_sentence=too_long, sentences=[ok])
     with pytest.raises(ValueError):
         model.run_sentence_similarity(source_sentence=ok, sentences=[too_long])
 
-    model.run_sentence_similarities(source_sentences=[ok], sentences=[ok])
     with pytest.raises(ValueError):
         model.run_sentence_similarities(source_sentences=[too_long], sentences=[ok])
     with pytest.raises(ValueError):
         model.run_sentence_similarities(source_sentences=[ok], sentences=[too_long])
 
     # reranker test both query and document text
-    model.run_rerank_query(query=ok, documents=[{"text": ok}])
     with pytest.raises(ValueError):
         model.run_rerank_query(query=too_long, documents=[{"text": ok}])
     with pytest.raises(ValueError):
         model.run_rerank_query(query=ok, documents=[{"text": too_long}])
 
-    model.run_rerank_queries(queries=[ok], documents=[{"text": ok}])
     with pytest.raises(ValueError):
         model.run_rerank_queries(queries=[too_long], documents=[{"text": ok}])
     with pytest.raises(ValueError):
         model.run_rerank_queries(queries=[ok], documents=[{"text": too_long}])
+
+
+@pytest.mark.parametrize("truncate_input_tokens", [0, 513])
+def test_too_many_tokens_error_params(truncate_input_tokens):
+    """truncate_input_tokens does not prevent these endpoints from raising an error.
+
+    Test with 0 which uses the max model len (512) to determine truncation and raise error.
+    Test with 513 (> 512) which detects truncation over 512 and raises an error.
+    """
+
+    model = BOOTSTRAPPED_MODEL
+    model_max = model.model.max_seq_length
+
+    ok = "x " * (model_max - 2)  # Subtract 2 for begin/end tokens
+    too_long = "x " * (model_max - 1)  # This will go over
+
+    # embedding(s)
+    with pytest.raises(ValueError):
+        model.run_embedding(text=too_long, truncate_input_tokens=truncate_input_tokens)
+    with pytest.raises(ValueError):
+        model.run_embeddings(
+            texts=[too_long], truncate_input_tokens=truncate_input_tokens
+        )
+
+    # sentence similarity(ies) test both source_sentence and sentences
+    with pytest.raises(ValueError):
+        model.run_sentence_similarity(
+            source_sentence=too_long,
+            sentences=[ok],
+            truncate_input_tokens=truncate_input_tokens,
+        )
+    with pytest.raises(ValueError):
+        model.run_sentence_similarity(
+            source_sentence=ok,
+            sentences=[too_long],
+            truncate_input_tokens=truncate_input_tokens,
+        )
+
+    with pytest.raises(ValueError):
+        model.run_sentence_similarities(
+            source_sentences=[too_long],
+            sentences=[ok],
+            truncate_input_tokens=truncate_input_tokens,
+        )
+    with pytest.raises(ValueError):
+        model.run_sentence_similarities(
+            source_sentences=[ok],
+            sentences=[too_long],
+            truncate_input_tokens=truncate_input_tokens,
+        )
+
+    # reranker test both query and document text
+    with pytest.raises(ValueError):
+        model.run_rerank_query(
+            query=too_long,
+            documents=[{"text": ok}],
+            truncate_input_tokens=truncate_input_tokens,
+        )
+    with pytest.raises(ValueError):
+        model.run_rerank_query(
+            query=ok,
+            documents=[{"text": too_long}],
+            truncate_input_tokens=truncate_input_tokens,
+        )
+
+    with pytest.raises(ValueError):
+        model.run_rerank_queries(
+            queries=[too_long],
+            documents=[{"text": ok}],
+            truncate_input_tokens=truncate_input_tokens,
+        )
+    with pytest.raises(ValueError):
+        model.run_rerank_queries(
+            queries=[ok],
+            documents=[{"text": too_long}],
+            truncate_input_tokens=truncate_input_tokens,
+        )
+
+
+@pytest.mark.parametrize("truncate_input_tokens", [-1, 99, 512])
+def test_too_many_tokens_with_truncation_working(truncate_input_tokens):
+    """truncate_input_tokens prevents these endpoints from raising an error when too many tokens.
+
+    Test with -1 which lets the model do truncation instead of raising an error.
+    Test with 99 (< 512) which causes our code to do the truncation instead of raising an error.
+    """
+
+    model = BOOTSTRAPPED_MODEL
+    model_max = model.model.max_seq_length
+
+    ok = "x " * (model_max - 2)  # Subtract 2 for begin/end tokens
+    too_long = "x " * (model_max - 1)  # This will go over
+
+    # embedding(s)
+    model.run_embedding(text=too_long, truncate_input_tokens=truncate_input_tokens)
+    model.run_embeddings(texts=[too_long], truncate_input_tokens=truncate_input_tokens)
+
+    # sentence similarity(ies) test both source_sentence and sentences
+    model.run_sentence_similarity(
+        source_sentence=too_long,
+        sentences=[ok],
+        truncate_input_tokens=truncate_input_tokens,
+    )
+    model.run_sentence_similarity(
+        source_sentence=ok,
+        sentences=[too_long],
+        truncate_input_tokens=truncate_input_tokens,
+    )
+
+    model.run_sentence_similarities(
+        source_sentences=[too_long],
+        sentences=[ok],
+        truncate_input_tokens=truncate_input_tokens,
+    )
+    model.run_sentence_similarities(
+        source_sentences=[ok],
+        sentences=[too_long],
+        truncate_input_tokens=truncate_input_tokens,
+    )
+
+    # reranker test both query and document text
+    model.run_rerank_query(
+        query=too_long,
+        documents=[{"text": ok}],
+        truncate_input_tokens=truncate_input_tokens,
+    )
+    model.run_rerank_query(
+        query=ok,
+        documents=[{"text": too_long}],
+        truncate_input_tokens=truncate_input_tokens,
+    )
+
+    model.run_rerank_queries(
+        queries=[too_long],
+        documents=[{"text": ok}],
+        truncate_input_tokens=truncate_input_tokens,
+    )
+    model.run_rerank_queries(
+        queries=[ok],
+        documents=[{"text": too_long}],
+        truncate_input_tokens=truncate_input_tokens,
+    )

--- a/tests/modules/text_embedding/test_embedding.py
+++ b/tests/modules/text_embedding/test_embedding.py
@@ -447,32 +447,41 @@ def test__optimize(monkeypatch):
 def test_no_truncation():
     """These endpoints raise an error if truncation would happen."""
 
-    too_long = "hello " * 1000
-    ok = "hi "
-
     model = BOOTSTRAPPED_MODEL
+    model_max = model.model.max_seq_length
+
+    ok = "x " * (model_max - 2)  # Subtract 2 for begin/end tokens
+    too_long = "x " * (model_max - 1)  # This will go over
 
     # embedding(s)
+    model.run_embedding(text=ok)
     with pytest.raises(ValueError):
         model.run_embedding(text=too_long)
+    model.run_embeddings(texts=[ok])
     with pytest.raises(ValueError):
         model.run_embeddings(texts=[too_long])
 
     # sentence similarity(ies) test both source_sentence and sentences
+    model.run_sentence_similarity(source_sentence=ok, sentences=[ok])
     with pytest.raises(ValueError):
         model.run_sentence_similarity(source_sentence=too_long, sentences=[ok])
     with pytest.raises(ValueError):
         model.run_sentence_similarity(source_sentence=ok, sentences=[too_long])
+
+    model.run_sentence_similarities(source_sentences=[ok], sentences=[ok])
     with pytest.raises(ValueError):
         model.run_sentence_similarities(source_sentences=[too_long], sentences=[ok])
     with pytest.raises(ValueError):
         model.run_sentence_similarities(source_sentences=[ok], sentences=[too_long])
 
-    # reranker(s) test both source_sentence and sentences
+    # reranker test both query and document text
+    model.run_rerank_query(query=ok, documents=[{"text": ok}])
     with pytest.raises(ValueError):
         model.run_rerank_query(query=too_long, documents=[{"text": ok}])
     with pytest.raises(ValueError):
         model.run_rerank_query(query=ok, documents=[{"text": too_long}])
+
+    model.run_rerank_queries(queries=[ok], documents=[{"text": ok}])
     with pytest.raises(ValueError):
         model.run_rerank_queries(queries=[too_long], documents=[{"text": ok}])
     with pytest.raises(ValueError):


### PR DESCRIPTION
The desired functionality here is that a request which would be truncated (to work with a model max_seq_len) should instead return an error message.  The reasoning is that the client would want to know, instead of just getting results without realizing the impact of truncation.

In order to consider the token truncation (not string truncation), this requires tokenization up front and avoiding a warning about parallelism on the first attempt.

To be consistent with the user experience with other models, the default will throw an error with the models max_seq_len is exceeded (this is not the sentence-transformers default behavior so it is implemented here).  In addition, here we add the optional truncate_input_tokens parameter.  This is consistent with other services, and in addition to implementing the desired default behavior, this implements a passed-in truncation, or using sentence-transformers automatically truncate with -1 (and less overhead that way).

            truncate_input_tokens: int
                Truncation length for input tokens.
                If less than zero, this is disabled (returns texts without processing).
                If zero or greater than the model's maximum, then this is a test
                to see if truncation is needed. If needed, an exception is thrown.
                Otherwise, we take this usable truncation limit to truncate the tokens and then
                decode them to return truncated strings that can be used with this model.