### PR TITLE
dockerfile: build wheel in container

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,7 @@
 *
-!dist
 !README.md
 !LICENSE
+!caikit_nlp
+!pyproject.toml
+!tox.ini
+!.git

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -24,9 +24,6 @@ jobs:
         run: |
           pip install -U pip wheel
           pip install tox
-      - name: Build wheel
-        run: |
-          tox -e build
       - name: Build image
         run: |
           docker build -t caikit-nlp:latest .

--- a/tox.ini
+++ b/tox.ini
@@ -40,7 +40,6 @@ commands = pylint caikit_nlp
 description = build wheel
 deps =
     build
-    setuptools
 commands = python -m build
 skip_install = True
 


### PR DESCRIPTION
Dockerfile was consuming a previously built wheel because setuptools_scm requires access to the git repository. By mounting the `.git` directory at the build step, we can build in the container.
