### PR TITLE
Text Embedding: Fix concurrency errors

### DIFF
--- a/caikit_nlp/modules/text_embedding/embedding.py
+++ b/caikit_nlp/modules/text_embedding/embedding.py
@@ -304,9 +304,7 @@ class EmbeddingModule(ModuleBase):
                 ]
                 truncated_offsets = offsets[0]
                 start = next(
-                    idx
-                    for idx, val in (enumerate(truncated_offsets))
-                    if val != (0, 0)
+                    idx for idx, val in (enumerate(truncated_offsets)) if val != (0, 0)
                 )
                 end = next(
                     idx
@@ -315,9 +313,7 @@ class EmbeddingModule(ModuleBase):
                 )
                 # decode the truncated input tokens back to text to be returned
                 ret.append(
-                    text[
-                        truncated_offsets[start][0]: truncated_offsets[end][1]
-                    ]
+                    text[truncated_offsets[start][0] : truncated_offsets[end][1]]
                 )
 
             elif okay_to_truncate and not was_truncated:

--- a/caikit_nlp/modules/text_embedding/embedding.py
+++ b/caikit_nlp/modules/text_embedding/embedding.py
@@ -317,40 +317,21 @@ class EmbeddingModule(ModuleBase):
             max_length=max_length,
         )
 
-        for i, text in enumerate(texts):
-            mapping = tokenized["overflow_to_sample_mapping"]
-            lengths = [
-                tokenized["length"][idx] for idx, v in enumerate(mapping) if v == i
+        texts_map = tokenized["overflow_to_sample_mapping"]
+
+        for text_number, text in enumerate(texts):
+            # positions: the positions (in lengths and offsets arrays) that belong to this text
+            positions = [
+                position
+                for position, sample_number in enumerate(texts_map)
+                if sample_number == text_number
             ]
+            lengths = [tokenized["length"][pos] for pos in positions]
+
             was_truncated = len(lengths) > 1  # multiple lengths when truncated
 
-            if okay_to_truncate and was_truncated:
-                # Get the text offsets for the tokens that are kept after truncation
-                offsets = [
-                    tokenized["offset_mapping"][idx]
-                    for idx, v in enumerate(mapping)
-                    if v == i
-                ]
-                truncated_offsets = offsets[0]
-                # Find the first token offset (i.e. skip added start token)
-                start = next(
-                    idx for idx, val in (enumerate(truncated_offsets)) if val != (0, 0)
-                )
-                # Find the last token offset (i.e. skip added end token)
-                end = next(
-                    idx
-                    for idx, val in reversed(list(enumerate(truncated_offsets)))
-                    if val != (0, 0)
-                )
-                # Use the start/end offsets to slice the text based on token truncation
-                ret.append(
-                    text[truncated_offsets[start][0] : truncated_offsets[end][1]]
-                )
-
-            elif okay_to_truncate and not was_truncated:
-                ret.append(text)  # return original text
-
-            elif was_truncated:
+            if not okay_to_truncate and was_truncated:
+                # Raise error. We don't allow silent truncation in this case.
                 tokens = sum(lengths)  # add up total tokens for error message
                 error.log_raise(
                     "<NLP08391926E>",
@@ -359,6 +340,34 @@ class EmbeddingModule(ModuleBase):
                         f"maximum sequence length for this model ({tokens} > {max_tokens})."
                     ),
                 )
+
+            elif okay_to_truncate and not was_truncated:
+                ret.append(text)  # collect original text to return
+
+            elif okay_to_truncate and was_truncated:
+                # Truncate the text that maps to the truncated tokens.
+                # The offset_mapping describes the text position for each token.
+                # Added tokens were not in the text, so they show up as (0, 0).
+
+                # Get the text offsets for the tokens that are to be kept after truncation.
+                # Take the first set of offsets that mapped to this text's positions.
+                # This first set represents what will be kept after truncation.
+                # Each offset tells us which chars in the original text map to this token.
+                offsets = next(tokenized["offset_mapping"][pos] for pos in positions)
+
+                # Find the first offset that is not empty (0, 0) to avoid added tokens
+                start = next(offset for offset in offsets if offset != (0, 0))
+
+                # Find the last offset that is not empty (0, 0) to avoid added tokens
+                end = next(
+                    offset for offset in reversed(list(offsets)) if offset != (0, 0)
+                )
+
+                # Use the start-beginning end-ending to slice the text based on token truncation
+                # i.e. if start=(0,5) and end=(72,78) then we want slice [0:78]
+                truncated_text = text[start[0] : end[1]]
+
+                ret.append(truncated_text)  # return the truncated text for this one
 
         return ret
 

--- a/tests/modules/text_embedding/test_embedding.py
+++ b/tests/modules/text_embedding/test_embedding.py
@@ -73,6 +73,15 @@ SENTENCES = [d.get("text", d.get("_text")) for d in DOCS]
 ## Tests ########################################################################
 
 
+@pytest.fixture(scope="module")
+def loaded_model(tmp_path_factory):
+    models_dir = tmp_path_factory.mktemp("models")
+    model_path = str(models_dir / "model_id")
+    BOOTSTRAPPED_MODEL.save(model_path)
+    model = EmbeddingModule.load(model_path)
+    return model
+
+
 def _assert_is_expected_vector(vector):
     assert isinstance(vector.data.values[0], np.float32)
     assert len(vector.data.values) == 32
@@ -132,8 +141,8 @@ def _assert_valid_scores(scores, type_tests={}):
     return type_tests
 
 
-def test_bootstrap():
-    assert isinstance(BOOTSTRAPPED_MODEL, EmbeddingModule), "bootstrap error"
+def test_bootstrap_reuse():
+    assert isinstance(BOOTSTRAPPED_MODEL, EmbeddingModule), "bootstrap reuse error"
 
 
 def test_save_load_and_run():
@@ -192,31 +201,27 @@ def test_load_without_artifacts():
         EmbeddingModule.load(ModuleConfig({}))
 
 
-def test_run_embedding_type_check():
+def test_run_embedding_type_check(loaded_model):
     """Input cannot be a list"""
-    model = BOOTSTRAPPED_MODEL
     with pytest.raises(TypeError):
-        model.run_embedding([INPUT])
+        loaded_model.run_embedding([INPUT])
         pytest.fail("Should not reach here")
 
 
-def test_run_embedding():
-    model = BOOTSTRAPPED_MODEL
-    res = model.run_embedding(text=INPUT)
+def test_run_embedding(loaded_model):
+    res = loaded_model.run_embedding(text=INPUT)
     _assert_is_expected_embedding_result(res)
 
 
-def test_run_embeddings_str_type():
+def test_run_embeddings_str_type(loaded_model):
     """Supposed to be a list, gets fixed automatically."""
-    model = BOOTSTRAPPED_MODEL
-    res = model.run_embeddings(texts=INPUT)
+    res = loaded_model.run_embeddings(texts=INPUT)
     assert isinstance(res.results.vectors, list)
     assert len(res.results.vectors) == 1
 
 
-def test_run_embeddings():
-    model = BOOTSTRAPPED_MODEL
-    res = model.run_embeddings(texts=[INPUT])
+def test_run_embeddings(loaded_model):
+    res = loaded_model.run_embeddings(texts=[INPUT])
     assert isinstance(res.results.vectors, list)
     _assert_is_expected_embeddings_results(res.results)
 
@@ -231,16 +236,16 @@ def test_run_embeddings():
         (QUERY, DOCS, "topN string is not an integer or None"),
     ],
 )
-def test_run_rerank_query_type_error(query, docs, top_n):
+def test_run_rerank_query_type_error(query, docs, top_n, loaded_model):
     """test for type checks matching task/run signature"""
     with pytest.raises(TypeError):
-        BOOTSTRAPPED_MODEL.run_rerank_query(query=query, documents=docs, top_n=top_n)
+        loaded_model.run_rerank_query(query=query, documents=docs, top_n=top_n)
         pytest.fail("Should not reach here.")
 
 
-def test_run_rerank_query_no_type_error():
+def test_run_rerank_query_no_type_error(loaded_model):
     """no type error with list of string queries and list of dict documents"""
-    BOOTSTRAPPED_MODEL.run_rerank_query(query=QUERY, documents=DOCS, top_n=1)
+    loaded_model.run_rerank_query(query=QUERY, documents=DOCS, top_n=1)
 
 
 @pytest.mark.parametrize(
@@ -254,25 +259,25 @@ def test_run_rerank_query_no_type_error():
         (9999, len(DOCS)),
     ],
 )
-def test_run_rerank_query_top_n(top_n, expected):
-    res = BOOTSTRAPPED_MODEL.run_rerank_query(query=QUERY, documents=DOCS, top_n=top_n)
+def test_run_rerank_query_top_n(top_n, expected, loaded_model):
+    res = loaded_model.run_rerank_query(query=QUERY, documents=DOCS, top_n=top_n)
     assert isinstance(res, RerankResult)
     assert len(res.result.scores) == expected
 
 
-def test_run_rerank_query_no_query():
+def test_run_rerank_query_no_query(loaded_model):
     with pytest.raises(TypeError):
-        BOOTSTRAPPED_MODEL.run_rerank_query(query=None, documents=DOCS, top_n=99)
+        loaded_model.run_rerank_query(query=None, documents=DOCS, top_n=99)
 
 
-def test_run_rerank_query_zero_docs():
+def test_run_rerank_query_zero_docs(loaded_model):
     """No empty doc list therefore result is zero result scores"""
     with pytest.raises(ValueError):
-        BOOTSTRAPPED_MODEL.run_rerank_query(query=QUERY, documents=[], top_n=99)
+        loaded_model.run_rerank_query(query=QUERY, documents=[], top_n=99)
 
 
-def test_run_rerank_query():
-    res = BOOTSTRAPPED_MODEL.run_rerank_query(query=QUERY, documents=DOCS)
+def test_run_rerank_query(loaded_model):
+    res = loaded_model.run_rerank_query(query=QUERY, documents=DOCS)
     assert isinstance(res, RerankResult)
 
     scores = res.result.scores
@@ -286,16 +291,16 @@ def test_run_rerank_query():
 @pytest.mark.parametrize(
     "queries,docs", [("test string", DOCS), (QUERIES, {"testdict": "not list"})]
 )
-def test_run_rerank_queries_type_error(queries, docs):
+def test_run_rerank_queries_type_error(queries, docs, loaded_model):
     """type error check ensures params are lists and not just 1 string or just one doc (for example)"""
     with pytest.raises(TypeError):
-        BOOTSTRAPPED_MODEL.run_rerank_queries(queries=queries, documents=docs)
+        loaded_model.run_rerank_queries(queries=queries, documents=docs)
         pytest.fail("Should not reach here.")
 
 
-def test_run_rerank_queries_no_type_error():
+def test_run_rerank_queries_no_type_error(loaded_model):
     """no type error with list of string queries and list of dict documents"""
-    BOOTSTRAPPED_MODEL.run_rerank_queries(queries=QUERIES, documents=DOCS, top_n=99)
+    loaded_model.run_rerank_queries(queries=QUERIES, documents=DOCS, top_n=99)
 
 
 @pytest.mark.parametrize(
@@ -309,11 +314,9 @@ def test_run_rerank_queries_no_type_error():
         (9999, len(DOCS)),
     ],
 )
-def test_run_rerank_queries_top_n(top_n, expected):
+def test_run_rerank_queries_top_n(top_n, expected, loaded_model):
     """no type error with list of string queries and list of dict documents"""
-    res = BOOTSTRAPPED_MODEL.run_rerank_queries(
-        queries=QUERIES, documents=DOCS, top_n=top_n
-    )
+    res = loaded_model.run_rerank_queries(queries=QUERIES, documents=DOCS, top_n=top_n)
     assert isinstance(res, RerankResults)
     assert len(res.results) == len(QUERIES)
     for result in res.results:
@@ -329,16 +332,16 @@ def test_run_rerank_queries_top_n(top_n, expected):
     ],
     ids=["no queries", "no docs", "no queries and no docs"],
 )
-def test_run_rerank_queries_no_queries_or_no_docs(queries, docs):
+def test_run_rerank_queries_no_queries_or_no_docs(queries, docs, loaded_model):
     """No queries and/or no docs therefore result is zero results"""
 
     with pytest.raises(ValueError):
-        BOOTSTRAPPED_MODEL.run_rerank_queries(queries=queries, documents=docs, top_n=9)
+        loaded_model.run_rerank_queries(queries=queries, documents=docs, top_n=9)
 
 
-def test_run_rerank_queries():
+def test_run_rerank_queries(loaded_model):
     top_n = 2
-    rerank_result = BOOTSTRAPPED_MODEL.run_rerank_queries(
+    rerank_result = loaded_model.run_rerank_queries(
         queries=QUERIES, documents=DOCS, top_n=top_n
     )
     assert isinstance(rerank_result, RerankResults)
@@ -360,18 +363,20 @@ def test_run_rerank_queries():
     _assert_types_found(types_found)
 
 
-def test_run_sentence_similarity():
-    model = BOOTSTRAPPED_MODEL
-    res = model.run_sentence_similarity(source_sentence=QUERY, sentences=SENTENCES)
+def test_run_sentence_similarity(loaded_model):
+    res = loaded_model.run_sentence_similarity(
+        source_sentence=QUERY, sentences=SENTENCES
+    )
     scores = res.result.scores
     assert len(scores) == len(SENTENCES)
     for score in scores:
         assert isinstance(score, float)
 
 
-def test_run_sentence_similarities():
-    model = BOOTSTRAPPED_MODEL
-    res = model.run_sentence_similarities(source_sentences=QUERIES, sentences=SENTENCES)
+def test_run_sentence_similarities(loaded_model):
+    res = loaded_model.run_sentence_similarities(
+        source_sentences=QUERIES, sentences=SENTENCES
+    )
     results = res.results
     assert len(results) == len(QUERIES)
     for result in results:
@@ -444,136 +449,140 @@ def test__optimize(monkeypatch):
     assert fake == EmbeddingModule._optimize(fake, False, "bogus")
 
 
-@pytest.mark.parametrize(
-    "truncate_input_tokens, expected_len", [(99, 205), (333, 673), (-1, 1022)]
-)
-def test__truncate_input_tokens(truncate_input_tokens, expected_len):
-    model = BOOTSTRAPPED_MODEL
-    model_max = model.model.max_seq_length
+@pytest.mark.parametrize("truncate_input_tokens, expected_len", [(99, 205), (333, 673)])
+def test__truncate_input_tokens(truncate_input_tokens, expected_len, loaded_model):
 
-    too_long = "x " * (model_max - 1)  # This will go over
-    actual = model._truncate_input_tokens(
-        truncate_input_tokens=truncate_input_tokens, texts=[too_long]
+    too_long = "x  " * (truncate_input_tokens - 5) + "y  y  z  "  # z will go over
+    actual = loaded_model._truncate_input_tokens(
+        truncate_input_tokens=truncate_input_tokens, texts=[too_long, too_long]
     )[0]
 
-    assert len(actual) == expected_len
+    # TODO: Test -1 for no change in a separate test with a different string
+    # if truncate_input_tokens < 0:
+    # assert actual == too_long
+
+    # assert len(actual) == expected_len
+    assert len(actual) == (truncate_input_tokens - 2) * 3
+    assert actual == too_long
 
 
 @pytest.mark.parametrize("truncate_input_tokens", [0, 513])
-def test__truncate_input_tokens_raises(truncate_input_tokens):
-    model = BOOTSTRAPPED_MODEL
-    model_max = model.model.max_seq_length
+def test__truncate_input_tokens_raises(truncate_input_tokens, loaded_model):
+    model_max = loaded_model.model.max_seq_length
 
     too_long = "x " * (model_max - 1)  # This will go over
     with pytest.raises(ValueError):
-        model._truncate_input_tokens(
+        loaded_model._truncate_input_tokens(
             truncate_input_tokens=truncate_input_tokens, texts=[too_long]
         )
 
 
-def test_not_too_many_tokens():
+def test_not_too_many_tokens(loaded_model):
     """Happy path for the endpoints using text that is not too many tokens."""
 
-    model = BOOTSTRAPPED_MODEL
-    model_max = model.model.max_seq_length
+    model_max = loaded_model.model.max_seq_length
 
     ok = "x " * (model_max - 2)  # Subtract 2 for begin/end tokens
 
     # embedding(s)
-    model.run_embedding(text=ok)
-    model.run_embeddings(texts=[ok])
+    loaded_model.run_embedding(text=ok)
+    loaded_model.run_embeddings(texts=[ok])
 
     # sentence similarity(ies) test both source_sentence and sentences
-    model.run_sentence_similarity(source_sentence=ok, sentences=[ok])
-    model.run_sentence_similarities(source_sentences=[ok], sentences=[ok])
+    loaded_model.run_sentence_similarity(source_sentence=ok, sentences=[ok])
+    loaded_model.run_sentence_similarities(source_sentences=[ok], sentences=[ok])
 
     # reranker test both query and document text
-    model.run_rerank_query(query=ok, documents=[{"text": ok}])
-    model.run_rerank_queries(queries=[ok], documents=[{"text": ok}])
+    loaded_model.run_rerank_query(query=ok, documents=[{"text": ok}])
+    loaded_model.run_rerank_queries(queries=[ok], documents=[{"text": ok}])
 
 
-def test_too_many_tokens_default():
+def test_too_many_tokens_default(loaded_model):
     """These endpoints raise an error when truncation would happen."""
 
-    model = BOOTSTRAPPED_MODEL
-    model_max = model.model.max_seq_length
+    model_max = loaded_model.model.max_seq_length
 
     ok = "x " * (model_max - 2)  # Subtract 2 for begin/end tokens
     too_long = "x " * (model_max - 1)  # This will go over
 
     # embedding(s)
     with pytest.raises(ValueError):
-        model.run_embedding(text=too_long)
+        loaded_model.run_embedding(text=too_long)
     with pytest.raises(ValueError):
-        model.run_embeddings(texts=[too_long])
+        loaded_model.run_embeddings(texts=[too_long])
 
     # sentence similarity(ies) test both source_sentence and sentences
     with pytest.raises(ValueError):
-        model.run_sentence_similarity(source_sentence=too_long, sentences=[ok])
+        loaded_model.run_sentence_similarity(source_sentence=too_long, sentences=[ok])
     with pytest.raises(ValueError):
-        model.run_sentence_similarity(source_sentence=ok, sentences=[too_long])
+        loaded_model.run_sentence_similarity(source_sentence=ok, sentences=[too_long])
 
     with pytest.raises(ValueError):
-        model.run_sentence_similarities(source_sentences=[too_long], sentences=[ok])
+        loaded_model.run_sentence_similarities(
+            source_sentences=[too_long], sentences=[ok]
+        )
     with pytest.raises(ValueError):
-        model.run_sentence_similarities(source_sentences=[ok], sentences=[too_long])
+        loaded_model.run_sentence_similarities(
+            source_sentences=[ok], sentences=[too_long]
+        )
 
     # reranker test both query and document text
     with pytest.raises(ValueError):
-        model.run_rerank_query(query=too_long, documents=[{"text": ok}])
+        loaded_model.run_rerank_query(query=too_long, documents=[{"text": ok}])
     with pytest.raises(ValueError):
-        model.run_rerank_query(query=ok, documents=[{"text": too_long}])
+        loaded_model.run_rerank_query(query=ok, documents=[{"text": too_long}])
 
     with pytest.raises(ValueError):
-        model.run_rerank_queries(queries=[too_long], documents=[{"text": ok}])
+        loaded_model.run_rerank_queries(queries=[too_long], documents=[{"text": ok}])
     with pytest.raises(ValueError):
-        model.run_rerank_queries(queries=[ok], documents=[{"text": too_long}])
+        loaded_model.run_rerank_queries(queries=[ok], documents=[{"text": too_long}])
 
 
 @pytest.mark.parametrize("truncate_input_tokens", [0, 513])
-def test_too_many_tokens_error_params(truncate_input_tokens):
+def test_too_many_tokens_error_params(truncate_input_tokens, loaded_model):
     """truncate_input_tokens does not prevent these endpoints from raising an error.
 
     Test with 0 which uses the max model len (512) to determine truncation and raise error.
     Test with 513 (> 512) which detects truncation over 512 and raises an error.
     """
 
-    model = BOOTSTRAPPED_MODEL
-    model_max = model.model.max_seq_length
+    model_max = loaded_model.model.max_seq_length
 
     ok = "x " * (model_max - 2)  # Subtract 2 for begin/end tokens
     too_long = "x " * (model_max - 1)  # This will go over
 
     # embedding(s)
     with pytest.raises(ValueError):
-        model.run_embedding(text=too_long, truncate_input_tokens=truncate_input_tokens)
+        loaded_model.run_embedding(
+            text=too_long, truncate_input_tokens=truncate_input_tokens
+        )
     with pytest.raises(ValueError):
-        model.run_embeddings(
+        loaded_model.run_embeddings(
             texts=[too_long], truncate_input_tokens=truncate_input_tokens
         )
 
     # sentence similarity(ies) test both source_sentence and sentences
     with pytest.raises(ValueError):
-        model.run_sentence_similarity(
+        loaded_model.run_sentence_similarity(
             source_sentence=too_long,
             sentences=[ok],
             truncate_input_tokens=truncate_input_tokens,
         )
     with pytest.raises(ValueError):
-        model.run_sentence_similarity(
+        loaded_model.run_sentence_similarity(
             source_sentence=ok,
             sentences=[too_long],
             truncate_input_tokens=truncate_input_tokens,
         )
 
     with pytest.raises(ValueError):
-        model.run_sentence_similarities(
+        loaded_model.run_sentence_similarities(
             source_sentences=[too_long],
             sentences=[ok],
             truncate_input_tokens=truncate_input_tokens,
         )
     with pytest.raises(ValueError):
-        model.run_sentence_similarities(
+        loaded_model.run_sentence_similarities(
             source_sentences=[ok],
             sentences=[too_long],
             truncate_input_tokens=truncate_input_tokens,
@@ -581,26 +590,26 @@ def test_too_many_tokens_error_params(truncate_input_tokens):
 
     # reranker test both query and document text
     with pytest.raises(ValueError):
-        model.run_rerank_query(
+        loaded_model.run_rerank_query(
             query=too_long,
             documents=[{"text": ok}],
             truncate_input_tokens=truncate_input_tokens,
         )
     with pytest.raises(ValueError):
-        model.run_rerank_query(
+        loaded_model.run_rerank_query(
             query=ok,
             documents=[{"text": too_long}],
             truncate_input_tokens=truncate_input_tokens,
         )
 
     with pytest.raises(ValueError):
-        model.run_rerank_queries(
+        loaded_model.run_rerank_queries(
             queries=[too_long],
             documents=[{"text": ok}],
             truncate_input_tokens=truncate_input_tokens,
         )
     with pytest.raises(ValueError):
-        model.run_rerank_queries(
+        loaded_model.run_rerank_queries(
             queries=[ok],
             documents=[{"text": too_long}],
             truncate_input_tokens=truncate_input_tokens,
@@ -608,65 +617,102 @@ def test_too_many_tokens_error_params(truncate_input_tokens):
 
 
 @pytest.mark.parametrize("truncate_input_tokens", [-1, 99, 512])
-def test_too_many_tokens_with_truncation_working(truncate_input_tokens):
+def test_too_many_tokens_with_truncation_working(truncate_input_tokens, loaded_model):
     """truncate_input_tokens prevents these endpoints from raising an error when too many tokens.
 
     Test with -1 which lets the model do truncation instead of raising an error.
     Test with 99 (< 512) which causes our code to do the truncation instead of raising an error.
     """
 
-    model = BOOTSTRAPPED_MODEL
-    model_max = model.model.max_seq_length
+    model_max = loaded_model.model.max_seq_length
 
     ok = "x " * (model_max - 2)  # Subtract 2 for begin/end tokens
     too_long = "x " * (model_max - 1)  # This will go over
 
     # embedding(s)
-    model.run_embedding(text=too_long, truncate_input_tokens=truncate_input_tokens)
-    model.run_embeddings(texts=[too_long], truncate_input_tokens=truncate_input_tokens)
+    loaded_model.run_embedding(
+        text=too_long, truncate_input_tokens=truncate_input_tokens
+    )
+    loaded_model.run_embeddings(
+        texts=[too_long], truncate_input_tokens=truncate_input_tokens
+    )
 
     # sentence similarity(ies) test both source_sentence and sentences
-    model.run_sentence_similarity(
+    loaded_model.run_sentence_similarity(
         source_sentence=too_long,
         sentences=[ok],
         truncate_input_tokens=truncate_input_tokens,
     )
-    model.run_sentence_similarity(
+    loaded_model.run_sentence_similarity(
         source_sentence=ok,
         sentences=[too_long],
         truncate_input_tokens=truncate_input_tokens,
     )
 
-    model.run_sentence_similarities(
+    loaded_model.run_sentence_similarities(
         source_sentences=[too_long],
         sentences=[ok],
         truncate_input_tokens=truncate_input_tokens,
     )
-    model.run_sentence_similarities(
+    loaded_model.run_sentence_similarities(
         source_sentences=[ok],
         sentences=[too_long],
         truncate_input_tokens=truncate_input_tokens,
     )
 
     # reranker test both query and document text
-    model.run_rerank_query(
+    loaded_model.run_rerank_query(
         query=too_long,
         documents=[{"text": ok}],
         truncate_input_tokens=truncate_input_tokens,
     )
-    model.run_rerank_query(
+    loaded_model.run_rerank_query(
         query=ok,
         documents=[{"text": too_long}],
         truncate_input_tokens=truncate_input_tokens,
     )
 
-    model.run_rerank_queries(
+    loaded_model.run_rerank_queries(
         queries=[too_long],
         documents=[{"text": ok}],
         truncate_input_tokens=truncate_input_tokens,
     )
-    model.run_rerank_queries(
+    loaded_model.run_rerank_queries(
         queries=[ok],
         documents=[{"text": too_long}],
         truncate_input_tokens=truncate_input_tokens,
     )
+
+
+@pytest.mark.parametrize("truncate_input_tokens", [99, 512, -1])
+def test_embeddings_with_truncation(truncate_input_tokens, loaded_model):
+    """verify that results are as expected with truncation"""
+
+    if truncate_input_tokens is None or truncate_input_tokens < 0:
+        # For -1 we don't truncate, but sentence-transformers will truncate at max_seq_length
+        repeat = loaded_model.model.max_seq_length
+    else:
+        repeat = truncate_input_tokens
+
+    # Build a text like "x x x.. x " with room for one more token
+    repeat = repeat - 2  # space for start/end tokens
+    repeat = repeat - 1  # space for the final x or y token to show difference
+
+    base = "x " * repeat  # A bunch of "x" tokens
+    x = base + "x"  # One last "x" that will not get truncated
+    y = base + "y"  # A different last character "y" not truncated
+    z = y + "z"  # Add token "z" after "y". This should get truncated.
+
+    res = loaded_model.run_embeddings(
+        texts=[base, x, y, z], truncate_input_tokens=truncate_input_tokens
+    )
+
+    vectors = res.results.vectors
+
+    # x...xyz is the same as x...xy because that is exactly where truncation worked
+    assert np.allclose(vectors[2].data.values, vectors[3].data.values)
+
+    # Make sure the base, x, y are not a match (we kept the significant last char)
+    assert not np.allclose(vectors[0].data.values, vectors[1].data.values)
+    assert not np.allclose(vectors[0].data.values, vectors[2].data.values)
+    assert not np.allclose(vectors[1].data.values, vectors[2].data.values)


### PR DESCRIPTION
The use of tokenizer for truncation before using the sentence-transformers model to encode hits "Already borrowed" errors because the fast tokenizer (Rust) isn't very Python thread-friendly.

* Add retry to fix the problem and future problems
  * A simple retry loop usually fixes the problem immediately
  * Use a little sleep that increases
  * Add RETRY_COUNT so the max can be changed if needed
* Use a separate tokenizer instance for truncate
  * Using a separate copy of the tokenizer avoids the concurrency problem as reproduced so far
* Don't use decode()
  * Less use of tokenizer should help with above issues
  * This makes the truncated string more exactly as it should be.  With decode() is was an inexact reproduction inconsistent with non-truncated text handling.

* Add BATCH_SIZE env var to allow setting the sentence-transformers batch_size to use for performance testing/tuning

* More tests
* Use a loaded model in tests instead of a bootstrapped model

Note:  The truncation code requires a fast tokenizer (no change with this PR, but to-do for future)