### PR TITLE
calc_max_steps

### DIFF
--- a/caikit_nlp/modules/text_generation/peft_prompt_tuning.py
+++ b/caikit_nlp/modules/text_generation/peft_prompt_tuning.py
@@ -490,7 +490,7 @@ class PeftPromptTuning(ModuleBase):
                 num_epochs,
                 cls.RANDOM_SEED,
                 learning_rate,
-                max_steps=infer_max_steps(num_epochs, batch_size, training_dataset),
+                max_steps=infer_max_steps(num_epochs, batch_size, accumulate_steps, training_dataset),
                 silence_progress_bars=silence_progress_bars,
                 accumulate_steps=accumulate_steps,
                 # NOTE: following can override above arguments in order

--- a/caikit_nlp/toolkit/text_generation/training_utils.py
+++ b/caikit_nlp/toolkit/text_generation/training_utils.py
@@ -223,8 +223,10 @@ def launch_training(
 def infer_max_steps(
     num_epochs: int,
     batch_size: int,
+    ga_steps: int,
     training_dataset: Union[Dataset, TransformersIterableDataset],
 ):
+    batch_size = batch_size * ga_steps
     # Calculate the number of samples that we have
     if isinstance(training_dataset, Dataset):
         data_len = len(training_dataset)


### PR DESCRIPTION
the effective batch size is always per_Device_batch_size * gradient accumulation


with my testing : with gradient accumulation 4 , num_epochs = 20 

previously without fix it took 80 epochs as max_steps was 80 which overrides num_epochs. Takes evry long to train

after fix: 
finishes training in 23 epochs , which is closer to 20 specified . Train time has reduced


From this blog https://lightning.ai/blog/gradient-accumulation/
 `batch size of 256 but can only fit a batch size of 64 into GPU memory, we can perform gradient accumulation over four batches of size 64. (After processing all four batches, we will have the accumulated gradients equivalent to a single batch of size 256.) `
also here : https://discuss.huggingface.co/t/how-do-you-calculate-max-steps/40177 , same strategy is applied
