### PR TITLE
Embeddings: IPEX optimize requires model.eval() called first.

### DIFF
--- a/caikit_nlp/modules/text_embedding/embedding.py
+++ b/caikit_nlp/modules/text_embedding/embedding.py
@@ -153,6 +153,7 @@ class EmbeddingModule(ModuleBase):
         ipex = cls._get_ipex()
         device = cls._select_device(ipex)
         model = SentenceTransformer(model_name_or_path=artifacts_path, device=device)
+        model.eval()  # required for IPEX at least
         if device is not None:
             model.to(torch.device(device))
         model = EmbeddingModule._optimize(model, ipex, device)


### PR DESCRIPTION
Add an earlier model.eval() since embeddings models are always used for inference.

Fixes #317 