### PR TITLE
Add sentence-transformers to dependencies for real

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ dependencies = [
     "pandas>=1.5.0",
     "scikit-learn>=1.1",
     "scipy>=1.8.1",
+    "sentence-transformers>=2.3.1,<2.4.0",
     "tokenizers>=0.13.3",
     "torch>=2.0.1",
     "tqdm>=4.65.0",

--- a/sentence-transformers.nodeps.txt
+++ b/sentence-transformers.nodeps.txt
@@ -1,7 +1,0 @@
-# These can be installed with --no-deps.
-
-# Minimum needed to use sentence-transformers:
-sentence-transformers>=2.2.2,<2.3.0
-nltk>=3.8.1,<3.9.0
-Pillow>=10.0.0,<10.1.0
-

--- a/tox.ini
+++ b/tox.ini
@@ -15,9 +15,7 @@ passenv =
     LOG_FORMATTER
     LOG_THREAD_ID
     LOG_CHANNEL_WIDTH
-commands =
-    python -I -m pip install --force-reinstall --no-deps -r sentence-transformers.nodeps.txt
-    pytest --durations=42 --cov=caikit_nlp --cov-report=term --cov-report=html {posargs:tests}
+commands = pytest --durations=42 --cov=caikit_nlp --cov-report=term --cov-report=html {posargs:tests}
 
 ; Unclear: We probably want to test wheel packaging
 ; But! tox will fail when this is set and _any_ interpreter is missing


### PR DESCRIPTION
Need to make sentence-transformers part of the default caikit-nlp runtime image. Previously this was an optional import requiring a special runtime image.

* Make sentence-transformers one of the dependencies
* Remove the just-for-testing no-deps support that was a work-around