### PR TITLE
Wrapped sentence transformer

### DIFF
--- a/caikit_nlp/modules/text_embedding/embedding.py
+++ b/caikit_nlp/modules/text_embedding/embedding.py
@@ -14,13 +14,16 @@
 
 # Standard
 from copy import deepcopy
-from typing import List, Optional
+from typing import List, Optional, Union
 import importlib
 import os
 import time
 
 # Third Party
 from torch.backends import mps
+from transformers.tokenization_utils_base import TruncationStrategy
+import grpc
+import numpy as np
 import torch
 
 # First Party
@@ -47,6 +50,7 @@ from caikit.interfaces.nlp.tasks import (
     SentenceSimilarityTask,
     SentenceSimilarityTasks,
 )
+from caikit.runtime.types.caikit_runtime_exception import CaikitRuntimeException
 import alog
 
 logger = alog.use_channel("TXT_EMB")
@@ -59,6 +63,7 @@ try:
     # Third Party
     from sentence_transformers import SentenceTransformer
     from sentence_transformers.util import (
+        batch_to_device,
         cos_sim,
         dot_score,
         normalize_embeddings,
@@ -152,7 +157,9 @@ class EmbeddingModule(ModuleBase):
 
         ipex = cls._get_ipex()
         device = cls._select_device(ipex)
-        model = SentenceTransformer(model_name_or_path=artifacts_path, device=device)
+        model = SentenceTransformerWithTruncate(
+            model_name_or_path=artifacts_path, device=device
+        )
         model.eval()  # required for IPEX at least
         if device is not None:
             model.to(torch.device(device))
@@ -404,7 +411,11 @@ class EmbeddingModule(ModuleBase):
 
         text = self._truncate_input_tokens(truncate_input_tokens, [text])[0]
         return EmbeddingResult(
-            result=Vector1D.from_vector(self._encode_with_retry(text)),
+            result=Vector1D.from_vector(
+                self._encode_with_retry(
+                    text, truncate_input_tokens=truncate_input_tokens
+                )
+            ),
             producer_id=self.PRODUCER_ID,
         )
 
@@ -436,7 +447,9 @@ class EmbeddingModule(ModuleBase):
 
         texts = self._truncate_input_tokens(truncate_input_tokens, texts)
 
-        embeddings = self._encode_with_retry(texts)
+        embeddings = self._encode_with_retry(
+            texts, truncate_input_tokens=truncate_input_tokens
+        )
         vectors = [Vector1D.from_vector(e) for e in embeddings]
         return EmbeddingResults(
             results=ListOfVector1D(vectors=vectors), producer_id=self.PRODUCER_ID
@@ -470,8 +483,12 @@ class EmbeddingModule(ModuleBase):
         )[0]
         sentences = self._truncate_input_tokens(truncate_input_tokens, sentences)
 
-        source_embedding = self._encode_with_retry(source_sentence)
-        embeddings = self._encode_with_retry(sentences)
+        source_embedding = self._encode_with_retry(
+            source_sentence, truncate_input_tokens=truncate_input_tokens
+        )
+        embeddings = self._encode_with_retry(
+            sentences, truncate_input_tokens=truncate_input_tokens
+        )
 
         res = cos_sim(source_embedding, embeddings)
         return SentenceSimilarityResult(
@@ -508,8 +525,12 @@ class EmbeddingModule(ModuleBase):
         )
         sentences = self._truncate_input_tokens(truncate_input_tokens, sentences)
 
-        source_embedding = self._encode_with_retry(source_sentences)
-        embeddings = self._encode_with_retry(sentences)
+        source_embedding = self._encode_with_retry(
+            source_sentences, truncate_input_tokens=truncate_input_tokens
+        )
+        embeddings = self._encode_with_retry(
+            sentences, truncate_input_tokens=truncate_input_tokens
+        )
 
         res = cos_sim(source_embedding, embeddings)
         float_list_list = res.tolist()
@@ -665,15 +686,19 @@ class EmbeddingModule(ModuleBase):
         queries = self._truncate_input_tokens(truncate_input_tokens, queries)
 
         doc_embeddings = normalize_embeddings(
-            self._encode_with_retry(doc_texts, convert_to_tensor=True).to(
-                self.model.device
-            )
+            self._encode_with_retry(
+                doc_texts,
+                truncate_input_tokens=truncate_input_tokens,
+                convert_to_tensor=True,
+            ).to(self.model.device)
         )
 
         query_embeddings = normalize_embeddings(
-            self._encode_with_retry(queries, convert_to_tensor=True).to(
-                self.model.device
-            )
+            self._encode_with_retry(
+                queries,
+                truncate_input_tokens=truncate_input_tokens,
+                convert_to_tensor=True,
+            ).to(self.model.device)
         )
 
         res = semantic_search(
@@ -750,3 +775,102 @@ class EmbeddingModule(ModuleBase):
 
         # Save the config
         ModuleConfig(saver.config).save(model_config_path)
+
+
+class SentenceTransformerWithTruncate(SentenceTransformer):
+    def tokenize(self, texts: List[str], truncate_input_tokens: Optional[int] = 0):
+        if isinstance(texts[0], str):
+            to_tokenize = [texts]
+        else:
+            assert 0
+
+        to_tokenize = [[str(s).strip() for s in col] for col in to_tokenize]
+
+        # Lowercase
+        # if self.do_lower_case:
+        # to_tokenize = [[s.lower() for s in col] for col in to_tokenize]
+
+        # Do truncation if given a usable truncation value, else test for need to truncation
+        max_length = self.max_seq_length
+        if truncate_input_tokens < 0:
+            # Truncate using the model max (sentence-transfomers norm)
+            truncation = TruncationStrategy.LONGEST_FIRST
+        elif 0 < truncate_input_tokens <= max_length:
+            # Truncate using the passed in max
+            truncation = TruncationStrategy.LONGEST_FIRST
+            max_length = truncate_input_tokens
+        else:
+            # default (truncate_input_tokens=0 or anything over the model max)
+            # Model will return an error instead of truncating
+            truncation = TruncationStrategy.DO_NOT_TRUNCATE
+
+        output = {}  # TODO: no update needed
+        output.update(
+            self.tokenizer(
+                *to_tokenize,
+                padding=True,
+                truncation=truncation,
+                return_tensors="pt",
+                max_length=max_length,
+            )
+        )
+        # output.update(self.tokenizer(*to_tokenize, padding=True,
+        # truncation=TruncationStrategy.DO_NOT_TRUNCATE,
+        # # truncation=TruncationStrategy.DO_NOT_TRUNCATE,
+        # return_tensors="pt", max_length=self.max_seq_length))
+        return output
+
+    def encode(
+        self,
+        sentences: Union[str, List[str]],
+        batch_size: int = 32,
+        convert_to_numpy: bool = True,
+        convert_to_tensor: bool = False,
+        device: str = None,
+        truncate_input_tokens: Optional[int] = 0,
+    ) -> np.ndarray:
+
+        self.eval()
+        if convert_to_tensor:
+            convert_to_numpy = False
+
+        input_was_string = False
+        if isinstance(sentences, str) or not hasattr(
+            sentences, "__len__"
+        ):  # Cast an individual sentence to a list with length 1
+            sentences = [sentences]
+            input_was_string = True
+
+        if device is None:
+            device = self._target_device
+
+        self.to(device)
+
+        all_embeddings = []
+        length_sorted_idx = np.argsort([-self._text_length(sen) for sen in sentences])
+        sentences_sorted = [sentences[idx] for idx in length_sorted_idx]
+
+        for start_index in range(0, len(sentences), batch_size):
+            sentences_batch = sentences_sorted[start_index : start_index + batch_size]
+            features = self.tokenize(
+                sentences_batch, truncate_input_tokens=truncate_input_tokens
+            )
+            features = batch_to_device(features, device)
+
+            with torch.no_grad():
+                out_features = self.forward(features)
+                embeddings = out_features["sentence_embedding"]
+                if convert_to_numpy:
+                    embeddings = embeddings.detach().cpu()
+                all_embeddings.extend(embeddings)
+
+        all_embeddings = [all_embeddings[idx] for idx in np.argsort(length_sorted_idx)]
+        if convert_to_tensor:
+            all_embeddings = torch.stack(all_embeddings)
+        elif convert_to_numpy:
+            all_embeddings = np.asarray([emb.numpy() for emb in all_embeddings])
+
+        if input_was_string:
+            all_embeddings = all_embeddings[0]
+
+        return all_embeddings

--- a/tests/modules/text_embedding/test_embedding.py
+++ b/tests/modules/text_embedding/test_embedding.py
@@ -454,7 +454,8 @@ def test__truncate_input_tokens_raises(truncate_input_tokens, loaded_model):
     model_max = loaded_model.model.max_seq_length
 
     too_long = "x " * (model_max - 1)  # This will go over
-    with pytest.raises(ValueError):
+    over = model_max + 1
+    with pytest.raises(ValueError, match=f"({over} > {model_max})"):
         loaded_model.model.encode(
             sentences=[too_long], truncate_input_tokens=truncate_input_tokens
         )
@@ -484,40 +485,41 @@ def test_too_many_tokens_default(loaded_model):
     """These endpoints raise an error when truncation would happen."""
 
     model_max = loaded_model.model.max_seq_length
+    over = model_max + 1
 
     ok = "x " * (model_max - 2)  # Subtract 2 for begin/end tokens
     too_long = "x " * (model_max - 1)  # This will go over
 
     # embedding(s)
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match=f"({over} > {model_max})"):
         loaded_model.run_embedding(text=too_long)
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match=f"({over} > {model_max})"):
         loaded_model.run_embeddings(texts=[too_long])
 
     # sentence similarity(ies) test both source_sentence and sentences
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match=f"({over} > {model_max})"):
         loaded_model.run_sentence_similarity(source_sentence=too_long, sentences=[ok])
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match=f"({over} > {model_max})"):
         loaded_model.run_sentence_similarity(source_sentence=ok, sentences=[too_long])
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match=f"({over} > {model_max})"):
         loaded_model.run_sentence_similarities(
             source_sentences=[too_long], sentences=[ok]
         )
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match=f"({over} > {model_max})"):
         loaded_model.run_sentence_similarities(
             source_sentences=[ok], sentences=[too_long]
         )
 
     # reranker test both query and document text
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match=f"({over} > {model_max})"):
         loaded_model.run_rerank_query(query=too_long, documents=[{"text": ok}])
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match=f"({over} > {model_max})"):
         loaded_model.run_rerank_query(query=ok, documents=[{"text": too_long}])
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match=f"({over} > {model_max})"):
         loaded_model.run_rerank_queries(queries=[too_long], documents=[{"text": ok}])
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match=f"({over} > {model_max})"):
         loaded_model.run_rerank_queries(queries=[ok], documents=[{"text": too_long}])
 
 
@@ -530,41 +532,42 @@ def test_too_many_tokens_error_params(truncate_input_tokens, loaded_model):
     """
 
     model_max = loaded_model.model.max_seq_length
+    over = model_max + 1
 
     ok = "x " * (model_max - 2)  # Subtract 2 for begin/end tokens
     too_long = "x " * (model_max - 1)  # This will go over
 
     # embedding(s)
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match=f"({over} > {model_max})"):
         loaded_model.run_embedding(
             text=too_long, truncate_input_tokens=truncate_input_tokens
         )
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match=f"({over} > {model_max})"):
         loaded_model.run_embeddings(
             texts=[too_long], truncate_input_tokens=truncate_input_tokens
         )
 
     # sentence similarity(ies) test both source_sentence and sentences
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match=f"({over} > {model_max})"):
         loaded_model.run_sentence_similarity(
             source_sentence=too_long,
             sentences=[ok],
             truncate_input_tokens=truncate_input_tokens,
         )
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match=f"({over} > {model_max})"):
         loaded_model.run_sentence_similarity(
             source_sentence=ok,
             sentences=[too_long],
             truncate_input_tokens=truncate_input_tokens,
         )
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match=f"({over} > {model_max})"):
         loaded_model.run_sentence_similarities(
             source_sentences=[too_long],
             sentences=[ok],
             truncate_input_tokens=truncate_input_tokens,
         )
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match=f"({over} > {model_max})"):
         loaded_model.run_sentence_similarities(
             source_sentences=[ok],
             sentences=[too_long],
@@ -572,26 +575,26 @@ def test_too_many_tokens_error_params(truncate_input_tokens, loaded_model):
         )
 
     # reranker test both query and document text
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match=f"({over} > {model_max})"):
         loaded_model.run_rerank_query(
             query=too_long,
             documents=[{"text": ok}],
             truncate_input_tokens=truncate_input_tokens,
         )
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match=f"({over} > {model_max})"):
         loaded_model.run_rerank_query(
             query=ok,
             documents=[{"text": too_long}],
             truncate_input_tokens=truncate_input_tokens,
         )
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match=f"({over} > {model_max})"):
         loaded_model.run_rerank_queries(
             queries=[too_long],
             documents=[{"text": ok}],
             truncate_input_tokens=truncate_input_tokens,
         )
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match=f"({over} > {model_max})"):
         loaded_model.run_rerank_queries(
             queries=[ok],
             documents=[{"text": too_long}],


### PR DESCRIPTION
Wrapped sentence transformer to allow access to customized encode() and intercepting tokenizer() details.

* Needed for IPEX (Intel PyTorch extension) which needs bfloat16 and autocast settings to be effective.
* Allows us to get rid of the tokenizer copy that was needed for our desired truncation.  Now we leverage the same call SentenceTransformer was already doing anyway.

In order to keep the requested truncation error message, however, there is a re-tokenize just to get the correct error message.  This only happens on errors instead of impacting every request.