### PR TITLE
Include input token count in results

### DIFF
--- a/caikit_nlp/modules/text_embedding/embedding.py
+++ b/caikit_nlp/modules/text_embedding/embedding.py
@@ -687,9 +687,10 @@ def get_sample_start_indexes(tokenized: BatchEncoding) -> List[int]:
     # note: tokenized["overflow_to_sample_mapping"] is a torch.Tensor
 
     samples_start_indexes: Dict[int, int] = {}
-    for i, sample in enumerate(tokenized["overflow_to_sample_mapping"]):
-        if int(sample) not in samples_start_indexes:
-            samples_start_indexes[int(sample)] = i
+    for i, tensor_sample in enumerate(tokenized["overflow_to_sample_mapping"]):
+        int_sample = int(tensor_sample)
+        if int_sample not in samples_start_indexes:
+            samples_start_indexes[int_sample] = i
 
     return list(samples_start_indexes.values())
 

--- a/caikit_nlp/modules/text_embedding/embedding.py
+++ b/caikit_nlp/modules/text_embedding/embedding.py
@@ -842,7 +842,7 @@ class SentenceTransformerWithTruncate(SentenceTransformer):
         error.type_check_all("<NLP82314994E>", str, sentences=list_of_sentences)
 
         if device is None:
-            device = self._target_device
+            device = self.device
 
         self.to(device)
 

--- a/caikit_nlp/modules/text_embedding/embedding.py
+++ b/caikit_nlp/modules/text_embedding/embedding.py
@@ -707,7 +707,7 @@ def sum_token_count(
     """Returns the number of non-special tokens.
     Args:
         tokenized: BatchEncoding
-        only_truncated: bool
+        truncate_only: bool
     Returns:
         Int total of all tokens contained in tokenized.
     """

--- a/caikit_nlp/modules/text_embedding/embedding.py
+++ b/caikit_nlp/modules/text_embedding/embedding.py
@@ -21,7 +21,6 @@ import os
 import time
 
 # Third Party
-from regex import F
 from torch.backends import mps
 from transformers import BatchEncoding
 import numpy as np

--- a/caikit_nlp/modules/text_embedding/embedding.py
+++ b/caikit_nlp/modules/text_embedding/embedding.py
@@ -847,6 +847,9 @@ class SentenceTransformerWithTruncate(SentenceTransformer):
         self.to(device)
 
         all_embeddings = []
+
+        # Sort sentences according to length, from longest to shortest
+        # OOM errors then occurs at start of encoding
         length_sorted_idx = np.argsort(
             [-self._text_length(sen) for sen in list_of_sentences]
         )
@@ -880,6 +883,7 @@ class SentenceTransformerWithTruncate(SentenceTransformer):
                         embeddings = embeddings.detach().cpu()
                     all_embeddings.extend(embeddings)
 
+        # Restore original order
         all_embeddings = [all_embeddings[idx] for idx in np.argsort(length_sorted_idx)]
 
         if convert_to_tensor:

--- a/caikit_nlp/modules/text_embedding/embedding.py
+++ b/caikit_nlp/modules/text_embedding/embedding.py
@@ -686,12 +686,12 @@ def get_sample_start_indexes(tokenized: BatchEncoding) -> List[int]:
 
     # note: tokenized["overflow_to_sample_mapping"] is a torch.Tensor
 
-    samples_start_idx: Dict[int, int] = {}
-    for i, sample_idx in enumerate(tokenized["overflow_to_sample_mapping"]):
-        if sample_idx not in samples_start_idx:
-            samples_start_idx[sample_idx] = i
+    samples_start_indexes: Dict[int, int] = {}
+    for i, sample in enumerate(tokenized["overflow_to_sample_mapping"]):
+        if int(sample) not in samples_start_indexes:
+            samples_start_indexes[int(sample)] = i
 
-    return list(samples_start_idx.values())
+    return list(samples_start_indexes.values())
 
 
 class TruncateCountBehavior(Enum):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ classifiers=[
     "License :: OSI Approved :: Apache Software License"
 ]
 dependencies = [
-    "caikit[runtime-grpc,runtime-http]>=0.26.12,<0.27.0",
+    "caikit[runtime-grpc,runtime-http]>=0.26.14,<0.27.0",
     "caikit-tgis-backend>=0.1.27,<0.2.0",
     # TODO: loosen dependencies
     "accelerate>=0.22.0",

--- a/tests/modules/text_embedding/test_embedding.py
+++ b/tests/modules/text_embedding/test_embedding.py
@@ -46,7 +46,7 @@ MANY_INPUTS = [
 ]
 
 QUERY = "What is foo bar?"
-QUERY_TOKEN_COUNT = 13 + 2  # [CLS] 13 normal [SEP]
+QUERY_TOKEN_COUNT = 13 + 2  # [CLS] Whatisfoobar? [SEP]
 
 QUERIES: List[str] = [
     "Who is foo?",

--- a/tests/modules/text_embedding/test_embedding.py
+++ b/tests/modules/text_embedding/test_embedding.py
@@ -929,4 +929,4 @@ def test_get_sample_start_indexes(mapping, expected):
     mock_tokenized = {
         "overflow_to_sample_mapping": torch.Tensor(mapping).type(torch.int8)
     }
-    assert get_sample_start_indexes(mock_tokenized) == expected  # type: ignore
+    assert get_sample_start_indexes(mock_tokenized) == expected

--- a/tests/modules/text_embedding/test_embedding.py
+++ b/tests/modules/text_embedding/test_embedding.py
@@ -1,5 +1,5 @@
-"""Tests for text embedding module
-"""
+"""Tests for text embedding module"""
+
 # Standard
 from typing import List
 import os
@@ -33,6 +33,7 @@ from tests.fixtures import SEQ_CLASS_MODEL
 BOOTSTRAPPED_MODEL = EmbeddingModule.bootstrap(SEQ_CLASS_MODEL)
 
 INPUT = "The quick brown fox jumps over the lazy dog."
+INPUT_TOKEN_COUNT = 36  # Test tokenizer counts each non-whitespace character
 
 QUERY = "What is foo bar?"
 
@@ -95,6 +96,7 @@ def _assert_is_expected_embedding_result(actual):
     assert isinstance(actual, EmbeddingResult)
     vector = actual.result
     _assert_is_expected_vector(vector)
+    assert actual.input_token_count == INPUT_TOKEN_COUNT
 
 
 def _assert_is_expected_embeddings_results(actual):

--- a/tests/modules/text_embedding/test_embedding.py
+++ b/tests/modules/text_embedding/test_embedding.py
@@ -37,6 +37,11 @@ from tests.fixtures import SEQ_CLASS_MODEL
 # .bootstrap is tested separately in the first test
 BOOTSTRAPPED_MODEL = EmbeddingModule.bootstrap(SEQ_CLASS_MODEL)
 
+# Token counts:
+# All expected token counts were calculated with reference to the
+# `BertForSequenceClassification` model. Each model's tokenizer behaves differently
+# which can lead to the expected token counts being invalid.
+
 INPUT = "The quick brown fox jumps over the lazy dog."
 INPUT_TOKEN_COUNT = 36 + 2  # [CLS] Thequickbrownfoxjumpsoverthelazydog. [SEP]
 
@@ -825,6 +830,7 @@ def test_env_val_to_int():
 
 
 @pytest.mark.parametrize(
+    # `expected_count` are valid for the `BertForSequenceClassification` model.
     ["texts", "expected_count"],
     [
         # Only tokens requiring model attention is counted.
@@ -849,6 +855,7 @@ def test_sum_token_count_no_truncation(texts, expected_count, loaded_model):
 
 
 @pytest.mark.parametrize(
+    # `expected_count` are valid for the `BertForSequenceClassification` model.
     ["texts", "truncate", "expected_count"],
     [
         # Only tokens requiring model attention is counted.


### PR DESCRIPTION
Depends on caikit data model updates in this PR: https://github.com/caikit/caikit/pull/675

This extends the embedding module to include the `input_token_count` in the results of the `EmbeddingModule`'s `run_` methods.

The `sum_token_count(tokenized: BatchEncoding) -> int` function calculates the count of tokens requiring model attention, based on the `Encoding.attention_mask` property, as returned by `SentenceTransformerWithTruncate.tokenizer()`. [PAD] is irrelevant for truncation and max_token_count parameters, while [CLS] and [SEP] are counted by the model when it considers the max length and truncation.

Additionally tests to confirm sort order is maintained was added.

Various other quality of life type hints were added.