### PR TITLE
:sparkles: Add tokenization task to generation modules

### DIFF
--- a/caikit_nlp/modules/text_generation/peft_prompt_tuning.py
+++ b/caikit_nlp/modules/text_generation/peft_prompt_tuning.py
@@ -48,8 +48,9 @@ from caikit.interfaces.nlp.data_model import (
     ClassificationTrainRecord,
     GeneratedTextResult,
     GeneratedTextStreamResult,
+    TokenizationResults,
 )
-from caikit.interfaces.nlp.tasks import TextGenerationTask
+from caikit.interfaces.nlp.tasks import TextGenerationTask, TokenizationTask
 import alog
 
 # Local
@@ -87,7 +88,7 @@ TRAINING_LOSS_LOG_FILENAME = "training_logs.jsonl"
     id="6655831b-960a-4dc5-8df4-867026e2cd41",
     name="Peft generation",
     version="0.1.0",
-    task=TextGenerationTask,
+    tasks=[TextGenerationTask, TokenizationTask],
 )
 class PeftPromptTuning(ModuleBase):
 
@@ -273,6 +274,22 @@ class PeftPromptTuning(ModuleBase):
             exponential_decay_length_penalty=exponential_decay_length_penalty,
             stop_sequences=stop_sequences,
         )
+
+    @TokenizationTask.taskmethod()
+    def run_tokenizer(
+        self,
+        text: str,
+    ) -> TokenizationResults:
+        """Run tokenization task against the model
+
+        Args:
+           text: str
+                Text to tokenize
+        Returns:
+            TokenizationResults
+                The token count
+        """
+        raise NotImplementedError("Tokenization not implemented for local")
 
     @classmethod
     def train(

--- a/caikit_nlp/modules/text_generation/text_generation_local.py
+++ b/caikit_nlp/modules/text_generation/text_generation_local.py
@@ -31,8 +31,8 @@ from caikit import get_config
 from caikit.core.data_model import DataStream
 from caikit.core.exceptions import error_handler
 from caikit.core.modules import ModuleBase, ModuleConfig, ModuleSaver, module
-from caikit.interfaces.nlp.data_model import GeneratedTextResult
-from caikit.interfaces.nlp.tasks import TextGenerationTask
+from caikit.interfaces.nlp.data_model import GeneratedTextResult, TokenizationResults
+from caikit.interfaces.nlp.tasks import TextGenerationTask, TokenizationTask
 import alog
 
 # Local
@@ -60,7 +60,7 @@ TRAINING_LOSS_LOG_FILENAME = "training_logs.jsonl"
     id="f9181353-4ccf-4572-bd1e-f12bcda26792",
     name="Text Generation",
     version="0.1.0",
-    task=TextGenerationTask,
+    tasks=[TextGenerationTask, TokenizationTask],
 )
 class TextGeneration(ModuleBase):
     """Module to provide text generation capabilities"""
@@ -521,6 +521,7 @@ class TextGeneration(ModuleBase):
                         json.dump(loss_log, f)
                         f.write("\n")
 
+    @TextGenerationTask.taskmethod()
     def run(
         self,
         text: str,
@@ -574,6 +575,22 @@ class TextGeneration(ModuleBase):
             task_type=self.model.TASK_TYPE,
             **kwargs,
         )
+
+    @TokenizationTask.taskmethod()
+    def run_tokenizer(
+        self,
+        text: str,
+    ) -> TokenizationResults:
+        """Run tokenization task against the model
+
+        Args:
+           text: str
+                Text to tokenize
+        Returns:
+            TokenizationResults
+                The token count
+        """
+        raise NotImplementedError("Tokenization not implemented for local")
 
     ################################## Private Functions ######################################
 

--- a/caikit_nlp/toolkit/torch_run.py
+++ b/caikit_nlp/toolkit/torch_run.py
@@ -24,7 +24,8 @@ import os
 
 # Third Party
 from torch import cuda
-from torch.distributed.launcher.api import LaunchConfig, Std
+from torch.distributed.elastic.multiprocessing.api import Std
+from torch.distributed.launcher.api import LaunchConfig
 import torch.distributed as dist
 
 # First Party

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
     "scipy>=1.8.1",
     "sentence-transformers>=2.3.1,<2.4.0",
     "tokenizers>=0.13.3",
-    "torch>=2.0.1",
+    "torch>=2.0.1,<2.3.0",
     "tqdm>=4.65.0",
     "transformers>=4.32.0",
     "peft==0.6.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
     "scipy>=1.8.1",
     "sentence-transformers>=2.3.1,<2.4.0",
     "tokenizers>=0.13.3",
-    "torch>=2.0.1,<2.3.0",
+    "torch>=2.0.1",
     "tqdm>=4.65.0",
     "transformers>=4.32.0",
     "peft==0.6.0",

--- a/tests/modules/text_generation/test_peft_prompt_tuning.py
+++ b/tests/modules/text_generation/test_peft_prompt_tuning.py
@@ -429,6 +429,14 @@ def test_run_exponential_decay_len_penatly_object(causal_lm_dummy_model):
     assert isinstance(pred, GeneratedTextResult)
 
 
+def test_run_tokenizer_not_implemented(causal_lm_dummy_model):
+    with pytest.raises(NotImplementedError):
+        causal_lm_dummy_model.run_tokenizer("This text doesn't matter")
+
+
+######################## Test train ###############################################
+
+
 def test_train_with_data_validation_raises(causal_lm_train_kwargs, set_cpu_device):
     """Check if we are able to throw error for when number of examples are more than configured limit"""
     patch_kwargs = {

--- a/tests/modules/text_generation/test_text_generation_local.py
+++ b/tests/modules/text_generation/test_text_generation_local.py
@@ -209,3 +209,9 @@ def test_zero_epoch_case(disable_wip):
     }
     model = TextGeneration.train(**train_kwargs)
     assert isinstance(model.model, HFAutoSeq2SeqLM)
+
+
+def test_run_tokenizer_not_implemented():
+    with pytest.raises(NotImplementedError):
+        model = TextGeneration.bootstrap(SEQ2SEQ_LM_MODEL)
+        model.run_tokenizer("This text doesn't matter")


### PR DESCRIPTION
Closes https://github.com/caikit/caikit-nlp/issues/350

Because `TextGenerationTGIS` is not a subclass but a backend type for `TextGeneration`, any additional tasks declared on the former were not actually getting added. By adding the additional tasks on `TextGeneration` and `PeftPromptTuning` respectively, this allows the tokenization tasks to be available on the TGIS backend implementations. Unimplemented functions have to be added or there will be errors.

Tokenization run functions could eventually be implemented since each LLM could be reasonably expected to have a tokenizer.

`Std` getting imported with `LaunchConfig` started to error in latest torch `2.3.0`. It was observed the `Std` object is at https://github.com/pytorch/pytorch/blame/main/torch/distributed/elastic/multiprocessing/api.py and not in the `LaunchConfig` and was potentially getting imported through another import to the launcher api. `tee` is no longer an arg on `LaunchConfig`. Since this was a breaking change, torch is now pinned below `2.3.0`.