### PR TITLE
prevent pip backtracking

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ RUN --mount=source=.git,target=.git,type=bind tox -e build
 
 FROM base as deploy
 
-RUN python -m venv /opt/caikit/
+RUN python -m venv --upgrade-deps /opt/caikit/
 
 ENV VIRTUAL_ENV=/opt/caikit
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,9 @@ dependencies = [
     "caikit[runtime-grpc,runtime-http]>=0.26.17,<0.27.0",
     "caikit-tgis-backend>=0.1.27,<0.2.0",
     # TODO: loosen dependencies
+    "grpcio>=1.62.2", # explicitly pin grpc dependencies to a recent version to avoid pip backtracking
+    "grpcio-reflection>=1.62.2",
+    "grpcio-health-checking>=1.62.2",
     "accelerate>=0.22.0",
     "datasets>=2.4.0",
     "huggingface-hub",


### PR DESCRIPTION
image builds are currently taking 5+h and failing because of pip backtracking.

- deps: pin grpc-\* to a recent version to avoid pip backtracking
- Dockerfile: create venv with updated pip/setuptools
