### PR TITLE
:pushpin: Disallow grpcio 1.64.0 for abstract method regression

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
     "caikit[runtime-grpc,runtime-http]>=0.26.17,<0.27.0",
     "caikit-tgis-backend>=0.1.27,<0.2.0",
     # TODO: loosen dependencies
-    "grpcio>=1.62.2", # explicitly pin grpc dependencies to a recent version to avoid pip backtracking
+    "grpcio>=1.62.2,!=1.64.0", # explicitly pin grpc dependencies to a recent version to avoid pip backtracking
     "grpcio-reflection>=1.62.2",
     "grpcio-health-checking>=1.62.2",
     "accelerate>=0.22.0",


### PR DESCRIPTION
Same as https://github.com/caikit/caikit/pull/720, needed now that we have `grpcio` included specifically here