### PR TITLE
logging around tgis timout config setting

### DIFF
--- a/caikit_nlp/toolkit/text_generation/tgis_utils.py
+++ b/caikit_nlp/toolkit/text_generation/tgis_utils.py
@@ -338,7 +338,7 @@ class TGISGenerationClient:
             self.tgis_req_timeout = None
 
         else:
-            log.debug
+            log.debug(
                 "<RUN57106696T>",
                 "Setting TGIS timeout value to  %d",
                 self.tgis_req_timeout,

--- a/caikit_nlp/toolkit/text_generation/tgis_utils.py
+++ b/caikit_nlp/toolkit/text_generation/tgis_utils.py
@@ -334,7 +334,7 @@ class TGISGenerationClient:
             or not isinstance(self.tgis_req_timeout, int)
             or self.tgis_req_timeout <= 0
         ):
-            log.info("<RUN57106697I>", "TGIS timeout not set")
+            log.debug("<RUN57106697I>", "TGIS timeout not set")
             self.tgis_req_timeout = None
 
         else:

--- a/caikit_nlp/toolkit/text_generation/tgis_utils.py
+++ b/caikit_nlp/toolkit/text_generation/tgis_utils.py
@@ -338,7 +338,7 @@ class TGISGenerationClient:
             self.tgis_req_timeout = None
 
         else:
-            log.info(
+            log.debug
                 "<RUN57106696T>",
                 "Setting TGIS timeout value to  %d",
                 self.tgis_req_timeout,

--- a/caikit_nlp/toolkit/text_generation/tgis_utils.py
+++ b/caikit_nlp/toolkit/text_generation/tgis_utils.py
@@ -329,6 +329,21 @@ class TGISGenerationClient:
 
         self.tgis_req_timeout = get_config().tgis_request_timeout
 
+        if (
+            not self.tgis_req_timeout
+            or not isinstance(self.tgis_req_timeout, int)
+            or self.tgis_req_timeout <= 0
+        ):
+            log.info("<RUN57106697I>", "TGIS timeout not set")
+            self.tgis_req_timeout = None
+
+        else:
+            log.info(
+                "<RUN57106696T>",
+                "Setting TGIS timeout value to  %d",
+                self.tgis_req_timeout,
+            )
+
     def unary_generate(
         self,
         text,


### PR DESCRIPTION
This PR adds logging to the tgis_req_timeout config setting, to add debug log surrounding this configuration and ensure proper setting. 