### PR TITLE
Lazy model connection & x-route-info

### DIFF
--- a/caikit_nlp/modules/text_generation/peft_tgis_remote.py
+++ b/caikit_nlp/modules/text_generation/peft_tgis_remote.py
@@ -73,7 +73,6 @@ class PeftPromptTuningTGIS(ModuleBase):  # pylint: disable=too-many-instance-att
     ) -> None:
         super().__init__()
 
-        # self._client = None
         self._tgis_backend = tgis_backend
         if enable_backend:
             error.type_check(

--- a/caikit_nlp/modules/text_generation/peft_tgis_remote.py
+++ b/caikit_nlp/modules/text_generation/peft_tgis_remote.py
@@ -14,7 +14,9 @@
 """This file contains a distributed backend implementation for leveraging the PEFT-trained
 prompt vectors in TGIS generation requests.
 """
+
 # Standard
+from functools import cached_property
 from typing import Iterable, List, Optional, Tuple, Union
 import os
 
@@ -32,6 +34,7 @@ from caikit.interfaces.nlp.data_model import (
     TokenizationResults,
 )
 from caikit.interfaces.nlp.tasks import TextGenerationTask, TokenizationTask
+from caikit.interfaces.runtime.data_model import RuntimeServerContextType
 from caikit_tgis_backend import TGISBackend
 import alog
 
@@ -40,6 +43,7 @@ from ...data_model import ExponentialDecayLengthPenalty
 from ...toolkit.text_generation.tgis_utils import (
     GENERATE_FUNCTION_TGIS_ARGS,
     TGISGenerationClient,
+    get_route_info,
 )
 from ...toolkit.verbalizer_utils import render_verbalizer
 from . import PeftPromptTuning
@@ -68,15 +72,15 @@ class PeftPromptTuningTGIS(ModuleBase):  # pylint: disable=too-many-instance-att
         prompt_artifacts: Optional[List[str]] = None,
     ) -> None:
         super().__init__()
-        # Configure the internal client
-        # NOTE: This is made optional for the cases where we do not need to execute `.run` function
-        # for example, bootstrapping a model to caikit format and saving.
-        self._client = None
+
+        # self._client = None
         self._tgis_backend = tgis_backend
         if enable_backend:
+            error.type_check(
+                "<NLP33971947E>", TGISBackend, tgis_backend=self._tgis_backend
+            )
             # get_client will also launch a local TGIS process and get the model
             # loaded when using the local TGIS backend
-            self._client = tgis_backend.get_client(base_model_name)
 
             # Tell the backend to load all of the available prompt files
             if prompt_artifacts:
@@ -106,6 +110,14 @@ class PeftPromptTuningTGIS(ModuleBase):  # pylint: disable=too-many-instance-att
             model_id = getattr(self, "base_model_name", None)
             if tgis_backend and prompt_cache_id and model_id:
                 tgis_backend.unload_prompt_artifacts(model_id, prompt_cache_id)
+
+    @cached_property
+    def _client(self):
+        # Configure the internal client
+        # NOTE: This is made optional for the cases where we do not need to execute `.run` function
+        # for example, bootstrapping a model to caikit format and saving.
+        if hasattr(self, "tgis_backend") and self._tgis_backend:
+            return self._tgis_backend.get_client(self.base_model_name)
 
     @classmethod
     def load(cls, model_path: str, load_backend: BackendBase) -> "PeftPromptTuningTGIS":
@@ -182,7 +194,7 @@ class PeftPromptTuningTGIS(ModuleBase):  # pylint: disable=too-many-instance-att
             )
 
     # pylint: disable=duplicate-code
-    @TextGenerationTask.taskmethod()
+    @TextGenerationTask.taskmethod(context_arg="context")
     def run(
         self,
         text: str,
@@ -206,6 +218,7 @@ class PeftPromptTuningTGIS(ModuleBase):  # pylint: disable=too-many-instance-att
         generated_tokens: bool = True,
         token_logprobs: bool = True,
         token_ranks: bool = True,
+        context: Optional[RuntimeServerContextType] = None,
     ) -> GeneratedTextResult:
         f"""Run inference against the model running in TGIS.
 
@@ -221,6 +234,9 @@ class PeftPromptTuningTGIS(ModuleBase):  # pylint: disable=too-many-instance-att
             self.enable_backend,
             "Backend must be configured and loaded with this module before executing `run` call.",
         )
+        if self._tgis_backend:
+            self._register_model_connection_with_context(context)
+
         verbalized_text = render_verbalizer(self.verbalizer, {"input": text})
         return self.tgis_generation_client.unary_generate(
             text=verbalized_text,
@@ -244,7 +260,7 @@ class PeftPromptTuningTGIS(ModuleBase):  # pylint: disable=too-many-instance-att
             stop_sequences=stop_sequences,
         )
 
-    @TextGenerationTask.taskmethod(output_streaming=True)
+    @TextGenerationTask.taskmethod(output_streaming=True, context_arg="context")
     def run_stream_out(
         self,
         text: str,
@@ -268,6 +284,7 @@ class PeftPromptTuningTGIS(ModuleBase):  # pylint: disable=too-many-instance-att
         generated_tokens: bool = True,
         token_logprobs: bool = True,
         token_ranks: bool = True,
+        context: Optional[RuntimeServerContextType] = None,
     ) -> Iterable[GeneratedTextStreamResult]:
         f"""Run output stream inferencing against the model running in TGIS
 
@@ -283,6 +300,10 @@ class PeftPromptTuningTGIS(ModuleBase):  # pylint: disable=too-many-instance-att
             "Backend must be configured and loaded with this module \
             before executing `run_stream_out` call.",
         )
+
+        if self._tgis_backend:
+            self._register_model_connection_with_context(context)
+
         verbalized_text = render_verbalizer(self.verbalizer, {"input": text})
         return self.tgis_generation_client.stream_generate(
             text=verbalized_text,
@@ -306,10 +327,11 @@ class PeftPromptTuningTGIS(ModuleBase):  # pylint: disable=too-many-instance-att
             stop_sequences=stop_sequences,
         )
 
-    @TokenizationTask.taskmethod()
+    @TokenizationTask.taskmethod(context_arg="context")
     def run_tokenizer(
         self,
         text: str,
+        context: Optional[RuntimeServerContextType] = None,
     ) -> TokenizationResults:
         """Run tokenization task against the model running in TGIS.
 
@@ -320,6 +342,21 @@ class PeftPromptTuningTGIS(ModuleBase):  # pylint: disable=too-many-instance-att
             TokenizationResults
                 The token count
         """
+        if self._tgis_backend:
+            self._register_model_connection_with_context(context)
+
         return self.tgis_generation_client.unary_tokenize(
             text=text,
         )
+
+    def _register_model_connection_with_context(
+        self, context: Optional[RuntimeServerContextType]
+    ):
+        ok, route_info = get_route_info(context)
+        if ok:
+            self._tgis_backend.register_model_connection(
+                self.base_model_name, {"hostname": route_info}
+            )
+        else:
+            self._tgis_backend.register_model_connection(self.base_model_name)
+        self._model_loaded = True

--- a/caikit_nlp/modules/text_generation/peft_tgis_remote.py
+++ b/caikit_nlp/modules/text_generation/peft_tgis_remote.py
@@ -357,7 +357,8 @@ class PeftPromptTuningTGIS(ModuleBase):  # pylint: disable=too-many-instance-att
         ok, route_info = get_route_info(context)
         if ok:
             log.debug(
-                "<NLP10705560D> Registering remote model connection with context override: 'hostname: %s'",
+                "<NLP10705560D> Registering remote model connection with context "
+                "override: 'hostname: %s'",
                 route_info,
             )
             self._tgis_backend.register_model_connection(

--- a/caikit_nlp/modules/text_generation/peft_tgis_remote.py
+++ b/caikit_nlp/modules/text_generation/peft_tgis_remote.py
@@ -356,6 +356,10 @@ class PeftPromptTuningTGIS(ModuleBase):  # pylint: disable=too-many-instance-att
         """
         ok, route_info = get_route_info(context)
         if ok:
+            log.debug(
+                "<NLP10705560D> Registering remote model connection with context override: 'hostname: %s'",
+                route_info,
+            )
             self._tgis_backend.register_model_connection(
                 self.base_model_name, {"hostname": route_info}, fill_with_defaults=True
             )

--- a/caikit_nlp/modules/text_generation/peft_tgis_remote.py
+++ b/caikit_nlp/modules/text_generation/peft_tgis_remote.py
@@ -115,7 +115,7 @@ class PeftPromptTuningTGIS(ModuleBase):  # pylint: disable=too-many-instance-att
         # Configure the internal client
         # NOTE: This is made optional for the cases where we do not need to execute `.run` function
         # for example, bootstrapping a model to caikit format and saving.
-        if hasattr(self, "tgis_backend") and self._tgis_backend:
+        if self._tgis_backend:
             return self._tgis_backend.get_client(self.base_model_name)
 
     @classmethod
@@ -351,10 +351,13 @@ class PeftPromptTuningTGIS(ModuleBase):  # pylint: disable=too-many-instance-att
     def _register_model_connection_with_context(
         self, context: Optional[RuntimeServerContextType]
     ):
+        """
+        Register a model connection with the configured TGISBackend.
+        """
         ok, route_info = get_route_info(context)
         if ok:
             self._tgis_backend.register_model_connection(
-                self.base_model_name, {"hostname": route_info}
+                self.base_model_name, {"hostname": route_info}, fill_with_defaults=True
             )
         else:
             self._tgis_backend.register_model_connection(self.base_model_name)

--- a/caikit_nlp/modules/text_generation/text_generation_tgis.py
+++ b/caikit_nlp/modules/text_generation/text_generation_tgis.py
@@ -249,8 +249,7 @@ class TextGenerationTGIS(ModuleBase):
             GeneratedTextResult
                 Generated text result produced by TGIS.
         """
-        if self._tgis_backend:
-            self._register_model_connection_with_context(context)
+        self._register_model_connection_with_context(context)
 
         if self._model_loaded:
             return self.tgis_generation_client.unary_generate(
@@ -308,8 +307,7 @@ class TextGenerationTGIS(ModuleBase):
         Returns:
             Iterable[GeneratedTextStreamResult]
         """
-        if self._tgis_backend:
-            self._register_model_connection_with_context(context)
+        self._register_model_connection_with_context(context)
 
         if self._model_loaded:
             return self.tgis_generation_client.stream_generate(
@@ -349,8 +347,7 @@ class TextGenerationTGIS(ModuleBase):
             TokenizationResults
                 The token count
         """
-        if self._tgis_backend:
-            self._register_model_connection_with_context(context)
+        self._register_model_connection_with_context(context)
 
         if self._model_loaded:
             return self.tgis_generation_client.unary_tokenize(
@@ -360,16 +357,18 @@ class TextGenerationTGIS(ModuleBase):
     def _register_model_connection_with_context(
         self, context: Optional[RuntimeServerContextType]
     ):
-        ok, route_info = get_route_info(context)
-        if ok:
-            log.debug(
-                "<NLP15770311D> Registering remote model connection with context "
-                "override: 'hostname: %s'",
-                route_info,
-            )
-            self._tgis_backend.register_model_connection(
-                self.model_name, {"hostname": route_info}, fill_with_defaults=True
-            )
-        else:
-            self._tgis_backend.register_model_connection(self.model_name)
-        self._model_loaded = True
+        """
+        Register a remote model connection with the configured TGISBackend if there is
+        a context override provided.
+        """
+        if self._tgis_backend:
+            if route_info := get_route_info(context):
+                log.debug(
+                    "<NLP15770311D> Registering remote model connection with context "
+                    "override: 'hostname: %s'",
+                    route_info,
+                )
+                self._tgis_backend.register_model_connection(
+                    self.model_name, {"hostname": route_info}, fill_with_defaults=True
+                )
+            self._model_loaded = True

--- a/caikit_nlp/modules/text_generation/text_generation_tgis.py
+++ b/caikit_nlp/modules/text_generation/text_generation_tgis.py
@@ -362,6 +362,10 @@ class TextGenerationTGIS(ModuleBase):
     ):
         ok, route_info = get_route_info(context)
         if ok:
+            log.debug(
+                "<NLP15770311D> Registering remote model connection with context override: 'hostname: %s'",
+                route_info,
+            )
             self._tgis_backend.register_model_connection(
                 self.model_name, {"hostname": route_info}, fill_with_defaults=True
             )

--- a/caikit_nlp/modules/text_generation/text_generation_tgis.py
+++ b/caikit_nlp/modules/text_generation/text_generation_tgis.py
@@ -363,7 +363,8 @@ class TextGenerationTGIS(ModuleBase):
         ok, route_info = get_route_info(context)
         if ok:
             log.debug(
-                "<NLP15770311D> Registering remote model connection with context override: 'hostname: %s'",
+                "<NLP15770311D> Registering remote model connection with context "
+                "override: 'hostname: %s'",
                 route_info,
             )
             self._tgis_backend.register_model_connection(

--- a/caikit_nlp/modules/text_generation/text_generation_tgis.py
+++ b/caikit_nlp/modules/text_generation/text_generation_tgis.py
@@ -109,6 +109,14 @@ class TextGenerationTGIS(ModuleBase):
         if self._tgis_backend:
             return self._tgis_backend.get_client(self.model_name)
 
+    @cached_property
+    def tgis_generation_client(self):
+        # Lazily create the generation client
+        # This in turn calls self._client which also lazily gets the tgis backend client
+        return TGISGenerationClient(
+            self.model_name, self._eos_token, self._client, self.PRODUCER_ID
+        )
+
     @classmethod
     def bootstrap(cls, model_path: str, load_backend: Union[BackendBase, None] = None):
         """Function to bootstrap a pre-trained transformers model and

--- a/caikit_nlp/toolkit/text_generation/tgis_utils.py
+++ b/caikit_nlp/toolkit/text_generation/tgis_utils.py
@@ -693,9 +693,11 @@ def get_route_info(
     context: Optional[RuntimeServerContextType],
 ) -> Tuple[bool, Optional[str]]:
     """
-    Returns a tuple `(True, x-route-info)` from context if "x-route-info" was found in the headers/metadata.
+    Returns a tuple `(True, x-route-info)` from context if "x-route-info" was found in
+    the headers/metadata.
 
-    Otherwise returns a tuple `(False, None)` if "x-route-info" was not found in the context or if context is None.
+    Otherwise returns a tuple `(False, None)` if "x-route-info" was not found in the
+    context or if context is None.
     """
     if context is None:
         return False, None

--- a/caikit_nlp/toolkit/text_generation/tgis_utils.py
+++ b/caikit_nlp/toolkit/text_generation/tgis_utils.py
@@ -14,7 +14,7 @@
 """This file is for helper functions related to TGIS."""
 
 # Standard
-from typing import Iterable, Optional, Tuple
+from typing import Iterable, Optional
 
 # Third Party
 import fastapi
@@ -692,7 +692,7 @@ class TGISGenerationClient:
 
 def get_route_info(
     context: Optional[RuntimeServerContextType],
-) -> Tuple[bool, Optional[str]]:
+) -> Optional[str]:
     """
     Returns a tuple `(True, x-route-info)` from context if "x-route-info" was found in
     the headers/metadata.
@@ -701,20 +701,20 @@ def get_route_info(
     context or if context is None.
     """
     if context is None:
-        return False, None
+        return None
 
     if isinstance(context, grpc.ServicerContext):
-        route_info = dict(context.invocation_metadata()).get(ROUTE_INFO_KEY)
+        route_info = dict(context.invocation_metadata()).get(ROUTE_INFO_HEADER_KEY)
         if route_info:
-            return True, route_info
+            return route_info
     elif isinstance(context, fastapi.Request):
-        route_info = context.headers.get(ROUTE_INFO_KEY)
+        route_info = context.headers.get(ROUTE_INFO_HEADER_KEY)
         if route_info:
-            return True, route_info
+            return route_info
     else:
         error.log_raise(
             "<NLP92615097E>",
             ValueError(f"context is of an unsupported type: {type(context)}"),
         )
 
-    return False, None
+    return None

--- a/caikit_nlp/toolkit/text_generation/tgis_utils.py
+++ b/caikit_nlp/toolkit/text_generation/tgis_utils.py
@@ -86,7 +86,8 @@ GRPC_TO_CAIKIT_CORE_STATUS = {
     grpc.StatusCode.UNAUTHENTICATED: CaikitCoreStatusCode.UNAUTHORIZED,
 }
 
-ROUTE_INFO_KEY = "x-route-info"
+# HTTP Header / gRPC Metadata key used to identify a route override
+ROUTE_INFO_HEADER_KEY = "x-route-info"
 
 
 def raise_caikit_core_exception(rpc_error: grpc.RpcError):

--- a/caikit_nlp/toolkit/text_generation/tgis_utils.py
+++ b/caikit_nlp/toolkit/text_generation/tgis_utils.py
@@ -716,5 +716,3 @@ def get_route_info(
             "<NLP92615097E>",
             ValueError(f"context is of an unsupported type: {type(context)}"),
         )
-
-    return None

--- a/caikit_nlp/toolkit/text_generation/tgis_utils.py
+++ b/caikit_nlp/toolkit/text_generation/tgis_utils.py
@@ -86,6 +86,8 @@ GRPC_TO_CAIKIT_CORE_STATUS = {
     grpc.StatusCode.UNAUTHENTICATED: CaikitCoreStatusCode.UNAUTHORIZED,
 }
 
+ROUTE_INFO_KEY = "x-route-info"
+
 
 def raise_caikit_core_exception(rpc_error: grpc.RpcError):
     """Helper to wrap logic of converting from grpc.RpcError ->
@@ -699,11 +701,11 @@ def get_route_info(
         return False, None
 
     if isinstance(context, grpc.ServicerContext):
-        route_info = dict(context.invocation_metadata()).get("x-route-info")
+        route_info = dict(context.invocation_metadata()).get(ROUTE_INFO_KEY)
         if route_info:
             return True, route_info
     elif isinstance(context, fastapi.Request):
-        route_info = context.headers.get("x-route-info")
+        route_info = context.headers.get(ROUTE_INFO_KEY)
         if route_info:
             return True, route_info
     else:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ classifiers=[
 ]
 dependencies = [
     "caikit[runtime-grpc,runtime-http]>=0.26.27,<0.27.0",
-    "caikit-tgis-backend>=0.1.27,<0.2.0",
+    "caikit-tgis-backend>=0.1.33,<0.2.0",
     # TODO: loosen dependencies
     "grpcio>=1.62.2", # explicitly pin grpc dependencies to a recent version to avoid pip backtracking
     "grpcio-reflection>=1.62.2",

--- a/tests/fixtures/__init__.py
+++ b/tests/fixtures/__init__.py
@@ -1,8 +1,8 @@
-"""Helpful fixtures for configuring individual unit tests.
-"""
+"""Helpful fixtures for configuring individual unit tests."""
+
 # Standard
 from contextlib import contextmanager
-from typing import Iterable, Optional
+from typing import Iterable, Optional, Union
 from unittest import mock
 import json
 import os
@@ -191,6 +191,7 @@ def requires_determinism(request):
 
 ### Common TGIS stub classes
 
+
 # Helper stubs / mocks; we use these to patch caikit so that we don't actually
 # test the TGIS backend directly, and instead stub the client and inspect the
 # args that we pass to it.
@@ -342,3 +343,15 @@ def temp_config(**overrides):
 
     with mock.patch.object(caikit.config.config, "_IMMUTABLE_CONFIG", local_config):
         yield local_config
+
+
+class TestServicerContext:
+    """
+    A dummy class for mimicking ServicerContext invocation metadata storage.
+    """
+
+    def __init__(self, metadata: dict[str, Union[str, bytes]]):
+        self.metadata = metadata
+
+    def invocation_metadata(self):
+        return list(self.metadata.items())

--- a/tests/modules/text_generation/test_text_generation_tgis.py
+++ b/tests/modules/text_generation/test_text_generation_tgis.py
@@ -19,6 +19,7 @@ import caikit
 from caikit_nlp.data_model import ExponentialDecayLengthPenalty, GenerationTrainRecord
 from caikit_nlp.modules.text_generation import TextGeneration, TextGenerationTGIS
 from caikit_nlp.resources.pretrained_model.hf_auto_seq2seq_lm import HFAutoSeq2SeqLM
+from tests.fixtures import set_cpu_device  # noqa
 from tests.fixtures import (
     CAUSAL_LM_MODEL,
     SEQ2SEQ_LM_MODEL,

--- a/tests/modules/text_generation/test_text_generation_tgis.py
+++ b/tests/modules/text_generation/test_text_generation_tgis.py
@@ -1,5 +1,5 @@
-"""Tests for text-generation module
-"""
+"""Tests for text-generation module"""
+
 # Standard
 from unittest import mock
 import os
@@ -12,6 +12,7 @@ import torch
 
 # First Party
 from caikit.interfaces.nlp.data_model import GeneratedTextResult
+from caikit_tgis_backend import TGISBackend
 import caikit
 
 # Local
@@ -23,7 +24,6 @@ from tests.fixtures import (
     SEQ2SEQ_LM_MODEL,
     StubTGISBackend,
     StubTGISClient,
-    set_cpu_device,
 )
 
 SAMPLE_TEXT = "Hello stub"
@@ -150,6 +150,26 @@ def test_remote_tgis_only_model():
     with tempfile.TemporaryDirectory() as model_dir:
         model.save(model_dir)
         TextGenerationTGIS.load(model_dir, load_backend=tgis_backend)
+
+
+def test_client_lazy_load():
+    """
+    Test that the TGISBackend client is lazy loaded
+    """
+    model_name = "model-name"
+    tgis_backend = TGISBackend(
+        {"connection": {"hostname": "{model_id}.localhost:1234"}}
+    )
+    model = TextGenerationTGIS(model_name, tgis_backend=tgis_backend)
+
+    # No tgis_backend client and _model_loaded still False
+    assert "_client" not in model.__dict__
+    assert not model.__dict__.get("_model_loaded", True)
+
+    # Client gets created on accessing ._client
+    client = model._client
+    assert client is not None
+    assert client
 
 
 ### Output streaming tests ##############################################################

--- a/tests/toolkit/text_generation/test_tgis_utils.py
+++ b/tests/toolkit/text_generation/test_tgis_utils.py
@@ -32,6 +32,7 @@ from caikit_tgis_backend.protobufs import generation_pb2
 
 # Local
 from caikit_nlp.toolkit.text_generation import tgis_utils
+from tests.fixtures import TestServicerContext
 
 ## Helpers #####################################################################
 
@@ -137,7 +138,10 @@ def test_TGISGenerationClient_rpc_errors(status_code, method):
     argvalues=[
         (
             fastapi.Request(
-                {"type": "http", "headers": [(b"x-route-info", b"sometext")]}
+                {
+                    "type": "http",
+                    "headers": [(tgis_utils.ROUTE_INFO_KEY.encode(), b"sometext")],
+                }
             ),
             True,
             "sometext",
@@ -146,6 +150,16 @@ def test_TGISGenerationClient_rpc_errors(status_code, method):
             fastapi.Request(
                 {"type": "http", "headers": [(b"route-info", b"sometext")]}
             ),
+            False,
+            None,
+        ),
+        (
+            TestServicerContext({tgis_utils.ROUTE_INFO_KEY: "sometext"}),
+            True,
+            "sometext",
+        ),
+        (
+            TestServicerContext({"route-info": "sometext"}),
             False,
             None,
         ),

--- a/tests/toolkit/text_generation/test_tgis_utils.py
+++ b/tests/toolkit/text_generation/test_tgis_utils.py
@@ -134,47 +134,42 @@ def test_TGISGenerationClient_rpc_errors(status_code, method):
 
 
 @pytest.mark.parametrize(
-    argnames=["context", "ok", "route_info"],
+    argnames=["context", "route_info"],
     argvalues=[
         (
             fastapi.Request(
                 {
                     "type": "http",
-                    "headers": [(tgis_utils.ROUTE_INFO_KEY.encode(), b"sometext")],
+                    "headers": [
+                        (tgis_utils.ROUTE_INFO_HEADER_KEY.encode(), b"sometext")
+                    ],
                 }
             ),
-            True,
             "sometext",
         ),
         (
             fastapi.Request(
                 {"type": "http", "headers": [(b"route-info", b"sometext")]}
             ),
-            False,
             None,
         ),
         (
-            TestServicerContext({tgis_utils.ROUTE_INFO_KEY: "sometext"}),
-            True,
+            TestServicerContext({tgis_utils.ROUTE_INFO_HEADER_KEY: "sometext"}),
             "sometext",
         ),
         (
             TestServicerContext({"route-info": "sometext"}),
-            False,
             None,
         ),
-        ("should raise ValueError", False, None),
-        (None, False, None),
+        ("should raise ValueError", None),
+        (None, None),
         # Uncertain how to create a grpc.ServicerContext object
     ],
 )
-def test_get_route_info(
-    context: RuntimeServerContextType, ok: bool, route_info: Optional[str]
-):
+def test_get_route_info(context: RuntimeServerContextType, route_info: Optional[str]):
     if not isinstance(context, (fastapi.Request, grpc.ServicerContext, type(None))):
         with pytest.raises(ValueError):
             tgis_utils.get_route_info(context)
     else:
-        actual_ok, actual_route_info = tgis_utils.get_route_info(context)
-        assert actual_ok == ok
+        actual_route_info = tgis_utils.get_route_info(context)
         assert actual_route_info == route_info


### PR DESCRIPTION
This PR adds support for respecting a TGIS hostname override (`x-route-info` header/metadata).

This is achieved by lazily registering the model connection with the TGISBackend when `.run()`/`run_stream_out()`/`run_tokenizer()` is called. The `x-route-info` header/metadata is read from the context arg.

Additionally:
- a `TextGenerationTGIS._tgis_backend` property was added to be consistent with `PeftPromptTuningTGIS`. The `TextGenerationTGIS.tgis_backend` property is conditional on the `tgis_backend` argument to be True, which made accessing `TextGenerationTGIS.tgis_backend` risky as it might not exist. The additional `_tgis_backend` property is guaranteed to exist, making using it simpler and less risky.

Depends on `caikit-tgis-backend>=0.1.33`