### PR TITLE
:construction_worker: Reclaim space on image build

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -17,6 +17,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      - name: Reclaim space
+        run: |
+          sudo rm -rf /opt/hostedtoolcache
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Build image


### PR DESCRIPTION
We've seen multiple PR build failures on the image build workflow with `buildx failed with: ERROR: failed to solve: rpc error: code = Unknown desc = write /opt/caikit/lib/python3.9/site-packages/torch/lib/libtorch_cpu.so: no space left on device`