### PR TITLE
relax torch restraint to allow 2.4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
     "scipy>=1.8.1",
     "sentence-transformers>=2.3.1,<2.4.0",
     "tokenizers>=0.13.3",
-    "torch>=2.3.1,<2.4.0",
+    "torch>=2.3.1,<2.5.0",
     "tqdm>=4.65.0",
     "transformers>=4.32.0",
     "peft==0.6.0",


### PR DESCRIPTION

Tested with `torch==2.4.0`
* ran inference requests against models in COS 
* tested against guardrails in the cluster
* tested the embeddings playbook 
* unable to tune a mode due to unrelated setup issues

The change relaxes the range so new nlp models using updated torch version will not be a blocker