### PR TITLE
:goal_net: Handle error details on inactive rpc errors

### DIFF
--- a/caikit_nlp/toolkit/text_generation/tgis_utils.py
+++ b/caikit_nlp/toolkit/text_generation/tgis_utils.py
@@ -485,8 +485,7 @@ class TGISGenerationClient:
                     raise CaikitCoreException(
                         caikit_status_code, INACTIVE_RPC_CONN_ERR_MESSAGE
                     ) from err
-                else:
-                    raise CaikitCoreException(caikit_status_code, details) from err
+                raise CaikitCoreException(caikit_status_code, details) from err
             except grpc.RpcError as err:
                 raise_caikit_core_exception(err)
 
@@ -676,8 +675,7 @@ class TGISGenerationClient:
                 raise CaikitCoreException(
                     caikit_status_code, INACTIVE_RPC_CONN_ERR_MESSAGE
                 ) from err
-            else:
-                raise CaikitCoreException(caikit_status_code, details) from err
+            raise CaikitCoreException(caikit_status_code, details) from err
         except grpc.RpcError as err:
             raise_caikit_core_exception(err)
 

--- a/caikit_nlp/toolkit/text_generation/tgis_utils.py
+++ b/caikit_nlp/toolkit/text_generation/tgis_utils.py
@@ -476,7 +476,7 @@ class TGISGenerationClient:
                     request, timeout=self.tgis_req_timeout
                 )
             except grpc._channel._InactiveRpcError as err:
-                log.error("<NLP30829218E>", err.details)
+                log.error("<NLP30829218E>", err.details())
                 caikit_status_code = GRPC_TO_CAIKIT_CORE_STATUS.get(
                     err.code(), CaikitCoreStatusCode.UNKNOWN
                 )
@@ -663,7 +663,7 @@ class TGISGenerationClient:
                     details=details,
                 )
         except grpc._channel._InactiveRpcError as err:
-            log.error("<NLP11829118E>", err.details)
+            log.error("<NLP11829118E>", err.details())
             caikit_status_code = GRPC_TO_CAIKIT_CORE_STATUS.get(
                 err.code(), CaikitCoreStatusCode.UNKNOWN
             )

--- a/caikit_nlp/toolkit/text_generation/tgis_utils.py
+++ b/caikit_nlp/toolkit/text_generation/tgis_utils.py
@@ -476,13 +476,17 @@ class TGISGenerationClient:
                     request, timeout=self.tgis_req_timeout
                 )
             except grpc._channel._InactiveRpcError as err:
-                log.error("<NLP30829218E>", err.details())
+                details = err.details()
+                log.error("<NLP30829218E>", details)
                 caikit_status_code = GRPC_TO_CAIKIT_CORE_STATUS.get(
                     err.code(), CaikitCoreStatusCode.UNKNOWN
                 )
-                raise CaikitCoreException(
-                    caikit_status_code, INACTIVE_RPC_CONN_ERR_MESSAGE
-                ) from err
+                if caikit_status_code == CaikitCoreStatusCode.CONNECTION_ERROR:
+                    raise CaikitCoreException(
+                        caikit_status_code, INACTIVE_RPC_CONN_ERR_MESSAGE
+                    ) from err
+                else:
+                    raise CaikitCoreException(caikit_status_code, details) from err
             except grpc.RpcError as err:
                 raise_caikit_core_exception(err)
 
@@ -663,13 +667,17 @@ class TGISGenerationClient:
                     details=details,
                 )
         except grpc._channel._InactiveRpcError as err:
-            log.error("<NLP11829118E>", err.details())
+            details = err.details()
+            log.error("<NLP11829118E>", details)
             caikit_status_code = GRPC_TO_CAIKIT_CORE_STATUS.get(
                 err.code(), CaikitCoreStatusCode.UNKNOWN
             )
-            raise CaikitCoreException(
-                caikit_status_code, INACTIVE_RPC_CONN_ERR_MESSAGE
-            ) from err
+            if caikit_status_code == CaikitCoreStatusCode.CONNECTION_ERROR:
+                raise CaikitCoreException(
+                    caikit_status_code, INACTIVE_RPC_CONN_ERR_MESSAGE
+                ) from err
+            else:
+                raise CaikitCoreException(caikit_status_code, details) from err
         except grpc.RpcError as err:
             raise_caikit_core_exception(err)
 


### PR DESCRIPTION
Previously #372 was added to give connection errors a more understandable user message, but this obscured some unary generation validation errors

In this PR:
- Serializing `err.details` was leading to JSON errors - this should be `err.details()`
- Non-connection errors such as validation errors [invalid argument] were getting surfaced with the inactive RPC connection message incorrectly


Test command with this fix
```
grpcurl -plaintext -H "mm-model-id: [model-id]" -d '{
  "stopSequences": [],
  "text": "sad",
  "tokenLogprobs": true
}' localhost:8085 caikit.runtime.Nlp.NlpService.TextGenerationTaskPredict
```