### PR TITLE
:arrow_up: Upgrade peft to upgrade transformers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
     "tokenizers>=0.13.3",
     "torch>=2.3.1,<2.6.0",
     "tqdm>=4.65.0",
-    "transformers>=4.44.0,<4.49.0",
+    "transformers>=4.44.0,<4.47.0",
     "peft>=0.13.0,<0.15.0",
 ]
 


### PR DESCRIPTION
- peft was quite old (0.6.0) and causing some test failures [wrong tensor dimensions] as transformers got upgraded, though peft does not pin any transformers bounds
- transformers 4.47+ causes some tests to hang after `test_peft_tgis_remote.py` and will require further investigation [this currently isn't reproducible locally for me]

Relates to: #381 