### PR TITLE
:ambulance: Fix tf keras package creating confusion at install time

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,13 +28,13 @@ dependencies = [
     "scikit-learn>=1.6.1",
     "scipy>=1.10.0",
     "sentence-transformers>=3.4.0,<3.5.0",
-    "tf-keras>=2.18.0",
     "tokenizers>=0.20.0",
     "torch>=2.3.1,<2.6.0",
     "tqdm>=4.67.0",
     "transformers>=4.48.3,<4.50.0",
     "peft==0.14.0",
 ]
+
 
 [tool.setuptools.packages.find]
 exclude = ["tests", "tests.*"]

--- a/tox.ini
+++ b/tox.ini
@@ -8,6 +8,7 @@ deps =
     pytest==7.1.3
     pytest-cov>=2.10.1,<3.0
     pytest-html>=3.1.1,<4.0
+    tf-keras>=2.18.0
     wheel>=0.38.4
 passenv =
     LOG_LEVEL


### PR DESCRIPTION
### Changes

- Move `tf-keras` to test dependencies as they are only required for working with the dummy models at test time.