### PR TITLE
Update verbalizer error message to include the relevant template string

### DIFF
--- a/caikit_nlp/toolkit/verbalizer_utils.py
+++ b/caikit_nlp/toolkit/verbalizer_utils.py
@@ -61,7 +61,7 @@ def render_verbalizer(verbalizer_template: str, source_object) -> str:
                {{output}} with getattr(source_object, "target").
             returns: "Source: machine Target: learning"
 
-    NOTE: This function will throw  KeyError/AttributeError if you try to grab a key or property
+    NOTE: This function will throw ValueError if you try to grab a key or property
     that is invalid.
 
     Args:
@@ -74,7 +74,7 @@ def render_verbalizer(verbalizer_template: str, source_object) -> str:
     """
     is_dict = isinstance(source_object, dict)
 
-    def replace_text(match_obj):
+    def replace_text(match_obj: re.Match):
         captured_groups = match_obj.groups()
         if len(captured_groups) != 1:
             error(

--- a/caikit_nlp/toolkit/verbalizer_utils.py
+++ b/caikit_nlp/toolkit/verbalizer_utils.py
@@ -90,8 +90,7 @@ def render_verbalizer(verbalizer_template: str, source_object) -> str:
                 error(
                     "<NLP97415192E>",
                     KeyError(
-                        "Requested template string '%s' is not a valid key in dict",
-                        index_object,
+                        f"Requested template string '{index_object}' is not a valid key in dict"
                     ),
                 )
             return source_object[index_object]

--- a/caikit_nlp/toolkit/verbalizer_utils.py
+++ b/caikit_nlp/toolkit/verbalizer_utils.py
@@ -99,8 +99,7 @@ def render_verbalizer(verbalizer_template: str, source_object) -> str:
             error(
                 "<NLP97715112E>",
                 AttributeError(
-                    "Requested template string '%s' is not a valid property of type",
-                    index_object,
+                    f"Requested template string '{index_object}' is not a valid property of type",
                 ),
             )
         return getattr(source_object, index_object)

--- a/caikit_nlp/toolkit/verbalizer_utils.py
+++ b/caikit_nlp/toolkit/verbalizer_utils.py
@@ -89,7 +89,7 @@ def render_verbalizer(verbalizer_template: str, source_object) -> str:
             if index_object not in source_object:
                 error(
                     "<NLP97415192E>",
-                    KeyError(
+                    ValueError(
                         f"Requested template string '{index_object}' is not a valid key in dict"
                     ),
                 )
@@ -98,7 +98,7 @@ def render_verbalizer(verbalizer_template: str, source_object) -> str:
         if not hasattr(source_object, index_object):
             error(
                 "<NLP97715112E>",
-                AttributeError(
+                ValueError(
                     f"Requested template string '{index_object}' is not a valid property of type",
                 ),
             )

--- a/caikit_nlp/toolkit/verbalizer_utils.py
+++ b/caikit_nlp/toolkit/verbalizer_utils.py
@@ -89,7 +89,10 @@ def render_verbalizer(verbalizer_template: str, source_object) -> str:
             if index_object not in source_object:
                 error(
                     "<NLP97415192E>",
-                    KeyError("Requested template string is not a valid key in dict"),
+                    KeyError(
+                        "Requested template string '%s' is not a valid key in dict",
+                        index_object,
+                    ),
                 )
             return source_object[index_object]
 
@@ -97,7 +100,8 @@ def render_verbalizer(verbalizer_template: str, source_object) -> str:
             error(
                 "<NLP97715112E>",
                 AttributeError(
-                    "Requested template string is not a valid property of type"
+                    "Requested template string '%s' is not a valid property of type",
+                    index_object,
                 ),
             )
         return getattr(source_object, index_object)

--- a/tests/toolkit/test_verbalizers.py
+++ b/tests/toolkit/test_verbalizers.py
@@ -70,12 +70,12 @@ def test_is_invalid_verbalizer():
 def test_invalid_attribute_verbalizer_substitution():
     """Ensure that if we try to render a placeholder that doesn't exist on our DM, we fail."""
     verbalizer_template = "text: {{sadness}}"
-    with pytest.raises(AttributeError):
+    with pytest.raises(ValueError):
         render_verbalizer(verbalizer_template, SAMPLE_DM)
 
 
 def test_invalid_key_verbalizer_substitution():
     """Ensure that if we try to render a placeholder that doesn't exist on our dict, we fail."""
     verbalizer_template = "text: {{sadness}}"
-    with pytest.raises(KeyError):
+    with pytest.raises(ValueError):
         render_verbalizer(verbalizer_template, SAMPLE_DICT)


### PR DESCRIPTION
Update the exception message to include the template field which is the cause for the error.