### PR TITLE
:arrow_up: Bump caikit range

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ classifiers=[
     "License :: OSI Approved :: Apache Software License"
 ]
 dependencies = [
-    "caikit[runtime-grpc,runtime-http]>=0.26.34,<0.28.0",
+    "caikit[runtime-grpc,runtime-http]>=0.26.34,<0.29.0",
     "caikit-tgis-backend>=0.1.36,<0.2.0",
     # TODO: loosen dependencies
     "grpcio>=1.62.2", # explicitly pin grpc dependencies to a recent version to avoid pip backtracking
@@ -23,7 +23,7 @@ dependencies = [
     "accelerate>=1.3.0",
     "datasets>=3.3.0",
     "huggingface-hub",
-    "numpy>=1.23.0",
+    "numpy>=1.23.0,<2",
     "pandas>=2.2.3",
     "scikit-learn>=1.6.1",
     "scipy>=1.10.0",


### PR DESCRIPTION
- Allow more flexible caikit versioning including dependent protobuf versions
- numpy>=2 has not been tested with caikit-nlp, so this is pinned